### PR TITLE
Fix package wiring and make release scripts scope-agnostic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
 
       - name: Publish platform packages
         run: |
-          npm publish --workspace @samuelfaj/distill-darwin-arm64 --access public
-          npm publish --workspace @samuelfaj/distill-darwin-x64 --access public
-          npm publish --workspace @samuelfaj/distill-linux-arm64 --access public
-          npm publish --workspace @samuelfaj/distill-linux-x64 --access public
+          npm publish --workspace packages/distill-darwin-arm64 --access public
+          npm publish --workspace packages/distill-darwin-x64 --access public
+          npm publish --workspace packages/distill-linux-arm64 --access public
+          npm publish --workspace packages/distill-linux-x64 --access public
 
       - name: Publish main package
-        run: npm publish --workspace @samuelfaj/distill --access public
+        run: npm publish --workspace packages/cli --access public

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Save **up to 99% of tokens** without losing the signal.
 
 ```bash
 ollama pull qwen3.5:2b
-npm i -g @samuelfaj/distill
+npm i -g @zeldocarina/distill
 ```
 
 Add in your global agent instructions file:

--- a/bun.lock
+++ b/bun.lock
@@ -5,44 +5,44 @@
       "name": "distill-workspace",
     },
     "packages/cli": {
-      "name": "@samuelfaj/distill",
+      "name": "@zeldocarina/distill",
       "version": "0.1.31",
       "bin": {
         "distill": "bin/distill.js",
       },
       "optionalDependencies": {
-        "@samuelfaj/distill-darwin-arm64": "0.1.0",
-        "@samuelfaj/distill-darwin-x64": "0.1.0",
-        "@samuelfaj/distill-linux-arm64": "0.1.0",
-        "@samuelfaj/distill-linux-x64": "0.1.0",
+        "@zeldocarina/distill-darwin-arm64": "0.1.31",
+        "@zeldocarina/distill-darwin-x64": "0.1.31",
+        "@zeldocarina/distill-linux-arm64": "0.1.31",
+        "@zeldocarina/distill-linux-x64": "0.1.31",
       },
     },
     "packages/distill-darwin-arm64": {
-      "name": "@samuelfaj/distill-darwin-arm64",
+      "name": "@zeldocarina/distill-darwin-arm64",
       "version": "0.1.31",
     },
     "packages/distill-darwin-x64": {
-      "name": "@samuelfaj/distill-darwin-x64",
+      "name": "@zeldocarina/distill-darwin-x64",
       "version": "0.1.31",
     },
     "packages/distill-linux-arm64": {
-      "name": "@samuelfaj/distill-linux-arm64",
+      "name": "@zeldocarina/distill-linux-arm64",
       "version": "0.1.31",
     },
     "packages/distill-linux-x64": {
-      "name": "@samuelfaj/distill-linux-x64",
+      "name": "@zeldocarina/distill-linux-x64",
       "version": "0.1.31",
     },
   },
   "packages": {
-    "@samuelfaj/distill": ["@samuelfaj/distill@workspace:packages/cli"],
+    "@zeldocarina/distill": ["@zeldocarina/distill@workspace:packages/cli"],
 
-    "@samuelfaj/distill-darwin-arm64": ["@samuelfaj/distill-darwin-arm64@workspace:packages/distill-darwin-arm64"],
+    "@zeldocarina/distill-darwin-arm64": ["@zeldocarina/distill-darwin-arm64@workspace:packages/distill-darwin-arm64"],
 
-    "@samuelfaj/distill-darwin-x64": ["@samuelfaj/distill-darwin-x64@workspace:packages/distill-darwin-x64"],
+    "@zeldocarina/distill-darwin-x64": ["@zeldocarina/distill-darwin-x64@workspace:packages/distill-darwin-x64"],
 
-    "@samuelfaj/distill-linux-arm64": ["@samuelfaj/distill-linux-arm64@workspace:packages/distill-linux-arm64"],
+    "@zeldocarina/distill-linux-arm64": ["@zeldocarina/distill-linux-arm64@workspace:packages/distill-linux-arm64"],
 
-    "@samuelfaj/distill-linux-x64": ["@samuelfaj/distill-linux-x64@workspace:packages/distill-linux-x64"],
+    "@zeldocarina/distill-linux-x64": ["@zeldocarina/distill-linux-x64@workspace:packages/distill-linux-x64"],
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,28 +9,28 @@
         "packages/*"
       ]
     },
-    "node_modules/@samuelfaj/distill": {
+    "node_modules/@zeldocarina/distill": {
       "resolved": "packages/cli",
       "link": true
     },
-    "node_modules/@samuelfaj/distill-darwin-arm64": {
+    "node_modules/@zeldocarina/distill-darwin-arm64": {
       "resolved": "packages/distill-darwin-arm64",
       "link": true
     },
-    "node_modules/@samuelfaj/distill-darwin-x64": {
+    "node_modules/@zeldocarina/distill-darwin-x64": {
       "resolved": "packages/distill-darwin-x64",
       "link": true
     },
-    "node_modules/@samuelfaj/distill-linux-arm64": {
+    "node_modules/@zeldocarina/distill-linux-arm64": {
       "resolved": "packages/distill-linux-arm64",
       "link": true
     },
-    "node_modules/@samuelfaj/distill-linux-x64": {
+    "node_modules/@zeldocarina/distill-linux-x64": {
       "resolved": "packages/distill-linux-x64",
       "link": true
     },
     "packages/cli": {
-      "name": "@samuelfaj/distill",
+      "name": "@zeldocarina/distill",
       "version": "0.1.31",
       "license": "MIT",
       "bin": {
@@ -40,29 +40,29 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@samuelfaj/distill-darwin-arm64": "0.1.0",
-        "@samuelfaj/distill-darwin-x64": "0.1.0",
-        "@samuelfaj/distill-linux-arm64": "0.1.0",
-        "@samuelfaj/distill-linux-x64": "0.1.0"
+        "@zeldocarina/distill-darwin-arm64": "0.1.31",
+        "@zeldocarina/distill-darwin-x64": "0.1.31",
+        "@zeldocarina/distill-linux-arm64": "0.1.31",
+        "@zeldocarina/distill-linux-x64": "0.1.31"
       }
     },
     "packages/distill-darwin-arm64": {
-      "name": "@samuelfaj/distill-darwin-arm64",
+      "name": "@zeldocarina/distill-darwin-arm64",
       "version": "0.1.31",
       "license": "MIT"
     },
     "packages/distill-darwin-x64": {
-      "name": "@samuelfaj/distill-darwin-x64",
+      "name": "@zeldocarina/distill-darwin-x64",
       "version": "0.1.31",
       "license": "MIT"
     },
     "packages/distill-linux-arm64": {
-      "name": "@samuelfaj/distill-linux-arm64",
+      "name": "@zeldocarina/distill-linux-arm64",
       "version": "0.1.31",
       "license": "MIT"
     },
     "packages/distill-linux-x64": {
-      "name": "@samuelfaj/distill-linux-x64",
+      "name": "@zeldocarina/distill-linux-x64",
       "version": "0.1.31",
       "license": "MIT"
     }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,7 @@
-# @samuelfaj/distill
+# @zeldocarina/distill
 
 Install with:
 
 ```bash
-npm i -g @samuelfaj/distill
+npm i -g @zeldocarina/distill
 ```

--- a/packages/cli/bin/distill.js
+++ b/packages/cli/bin/distill.js
@@ -5,12 +5,14 @@ const path = require("node:path");
 const { createRequire } = require("node:module");
 
 const requireFromHere = createRequire(__filename);
+const cliPackage = require("../package.json");
+const packageScope = cliPackage.name.split("/")[0];
 
 const PACKAGE_BY_TARGET = {
-  "darwin-arm64": "@samuelfaj/distill-darwin-arm64",
-  "darwin-x64": "@samuelfaj/distill-darwin-x64",
-  "linux-arm64": "@samuelfaj/distill-linux-arm64",
-  "linux-x64": "@samuelfaj/distill-linux-x64"
+  "darwin-arm64": `${packageScope}/distill-darwin-arm64`,
+  "darwin-x64": `${packageScope}/distill-darwin-x64`,
+  "linux-arm64": `${packageScope}/distill-linux-arm64`,
+  "linux-x64": `${packageScope}/distill-linux-x64`
 };
 
 function resolveBinaryPath() {
@@ -29,7 +31,7 @@ function resolveBinaryPath() {
     return path.join(path.dirname(packageJsonPath), "bin", "distill");
   } catch (error) {
     console.error(
-      `[distill] Missing platform package ${packageName}. Reinstall @samuelfaj/distill for this platform.`
+      `[distill] Missing platform package ${packageName}. Reinstall ${cliPackage.name} for this platform.`
     );
     process.exit(1);
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@samuelfaj/distill",
+  "name": "@zeldocarina/distill",
   "version": "0.1.31",
   "description": "Compress command output for downstream LLMs.",
   "license": "MIT",
@@ -14,10 +14,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@samuelfaj/distill-darwin-arm64": "0.1.1",
-    "@samuelfaj/distill-darwin-x64": "0.1.1",
-    "@samuelfaj/distill-linux-arm64": "0.1.1",
-    "@samuelfaj/distill-linux-x64": "0.1.1"
+    "@zeldocarina/distill-darwin-arm64": "0.1.31",
+    "@zeldocarina/distill-darwin-x64": "0.1.31",
+    "@zeldocarina/distill-linux-arm64": "0.1.31",
+    "@zeldocarina/distill-linux-x64": "0.1.31"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/distill-darwin-arm64/package.json
+++ b/packages/distill-darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@samuelfaj/distill-darwin-arm64",
+  "name": "@zeldocarina/distill-darwin-arm64",
   "version": "0.1.31",
   "license": "MIT",
   "files": [

--- a/packages/distill-darwin-x64/package.json
+++ b/packages/distill-darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@samuelfaj/distill-darwin-x64",
+  "name": "@zeldocarina/distill-darwin-x64",
   "version": "0.1.31",
   "license": "MIT",
   "files": [

--- a/packages/distill-linux-arm64/package.json
+++ b/packages/distill-linux-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@samuelfaj/distill-linux-arm64",
+  "name": "@zeldocarina/distill-linux-arm64",
   "version": "0.1.31",
   "license": "MIT",
   "files": [

--- a/packages/distill-linux-x64/package.json
+++ b/packages/distill-linux-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@samuelfaj/distill-linux-x64",
+  "name": "@zeldocarina/distill-linux-x64",
   "version": "0.1.31",
   "license": "MIT",
   "files": [

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -36,9 +36,22 @@ for (const binary of binaries) {
 }
 
 const cliManifest = manifests[0];
+const packageScope = cliManifest.name.split("/")[0];
+const expectedPlatformPackageNames = new Set([
+  `${packageScope}/distill-darwin-arm64`,
+  `${packageScope}/distill-darwin-x64`,
+  `${packageScope}/distill-linux-arm64`,
+  `${packageScope}/distill-linux-x64`
+]);
 
-if (cliManifest.name !== "@samuelfaj/distill") {
-  throw new Error("Main package name must stay @samuelfaj/distill.");
+if (!cliManifest.name.endsWith("/distill")) {
+  throw new Error(`Main package name must end with /distill. Received ${cliManifest.name}.`);
+}
+
+for (const manifest of manifests.slice(1)) {
+  if (!expectedPlatformPackageNames.has(manifest.name)) {
+    throw new Error(`Unexpected platform package name: ${manifest.name}`);
+  }
 }
 
 if (requirePublishMetadata) {

--- a/scripts/smoke-packages.ts
+++ b/scripts/smoke-packages.ts
@@ -8,14 +8,15 @@ import cliPackage from "../packages/cli/package.json";
 const root = path.resolve(import.meta.dir, "..");
 const packDir = await mkdtemp(path.join(tmpdir(), "distill-pack-"));
 const installDir = await mkdtemp(path.join(tmpdir(), "distill-install-"));
+const packageScope = cliPackage.name.split("/")[0];
 
 const currentPlatformPackage = (() => {
   const key = `${process.platform}-${process.arch}`;
   const mapping: Record<string, string> = {
-    "darwin-arm64": "@samuelfaj/distill-darwin-arm64",
-    "darwin-x64": "@samuelfaj/distill-darwin-x64",
-    "linux-arm64": "@samuelfaj/distill-linux-arm64",
-    "linux-x64": "@samuelfaj/distill-linux-x64"
+    "darwin-arm64": `${packageScope}/distill-darwin-arm64`,
+    "darwin-x64": `${packageScope}/distill-darwin-x64`,
+    "linux-arm64": `${packageScope}/distill-linux-arm64`,
+    "linux-x64": `${packageScope}/distill-linux-x64`
   };
 
   const value = mapping[key];
@@ -52,7 +53,7 @@ function runOrThrow(command: string, args: string[], cwd: string, env?: NodeJS.P
 
 try {
   runOrThrow("npm", ["pack", "--workspace", currentPlatformPackage, "--pack-destination", packDir], root);
-  runOrThrow("npm", ["pack", "--workspace", "@samuelfaj/distill", "--pack-destination", packDir], root);
+  runOrThrow("npm", ["pack", "--workspace", cliPackage.name, "--pack-destination", packDir], root);
   runOrThrow("npm", ["init", "-y"], installDir);
 
   const tarballs = readdirSync(packDir)

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -16,17 +16,18 @@ setDefaultTimeout(60_000);
 
 const root = path.resolve(import.meta.dir, "..");
 const launcher = path.join(root, "packages", "cli", "bin", "distill.js");
-const expectedVersion = "0.1.0";
+const expectedVersion = cliPackage.version;
+const packageScope = cliPackage.name.split("/")[0];
 const WATCH_IDLE_MS = 1_800;
 const WATCH_START_DELAY_MS = 600;
 const INTERACTIVE_DELAY_MS = 1_000;
 const currentPlatformPackage = (() => {
   const key = `${process.platform}-${process.arch}`;
   const mapping: Record<string, string> = {
-    "darwin-arm64": "@samuelfaj/distill-darwin-arm64",
-    "darwin-x64": "@samuelfaj/distill-darwin-x64",
-    "linux-arm64": "@samuelfaj/distill-linux-arm64",
-    "linux-x64": "@samuelfaj/distill-linux-x64"
+    "darwin-arm64": `${packageScope}/distill-darwin-arm64`,
+    "darwin-x64": `${packageScope}/distill-darwin-x64`,
+    "linux-arm64": `${packageScope}/distill-linux-arm64`,
+    "linux-x64": `${packageScope}/distill-linux-x64`
   };
 
   const value = mapping[key];
@@ -349,7 +350,7 @@ describe("distill end-to-end", () => {
       );
       runOrThrow(
         "npm",
-        ["pack", "--workspace", "@samuelfaj/distill", "--pack-destination", packDir],
+        ["pack", "--workspace", cliPackage.name, "--pack-destination", packDir],
         root
       );
       runOrThrow("npm", ["init", "-y"], installDir);


### PR DESCRIPTION
## Summary
- fix the platform package wiring so the published CLI depends on matching platform package versions
- remove hardcoded package scope assumptions from launcher, smoke tests, release checks, and workflow publishing
- align docs, lockfiles, and e2e expectations with the actual package version and workspace names

## Why
The current published package metadata points the CLI package at older platform package versions, so installing the latest CLI can still resolve older native binaries. This PR makes the release flow scope-agnostic and keeps the workspace metadata internally consistent.

## Verification
- npm run verify
- npm run smoke:pack
