### PR TITLE
Add Windows support with platform-specific binaries and update docume…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 .dist/
 coverage/
-packages/distill-*/bin/distill
+packages/distill-*/bin/distill*
 npm-debug.log*
 *.tgz

--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ Save **up to 99% of tokens** without losing the signal.
 npm i -g @samuelfaj/distill
 ```
 
+`distill` now works on macOS, Linux, and Windows x64 through the published native platform packages.
+
 You can also point `distill` at OpenAI-compatible providers such as LM Studio, Jan, LocalAI, vLLM, SGLang, llama.cpp-compatible servers, MLX-based servers, and Docker Model Runner.
 
-Add in your global agent instructions file:
+## GitHub Copilot CLI global instructions
+
+GitHub Copilot CLI supports local global instructions from `$HOME/.copilot/copilot-instructions.md`. Create that file and add:
 
 ```md
 CRITICAL: Pipe every non-interactive shell command through `distill` unless raw output is explicitly required.
@@ -43,6 +47,39 @@ You may skip `distill` only in these cases:
 
 CRITICAL: Wait for `distill` to finish before continuing.
 ```
+
+PowerShell example on Windows:
+
+```powershell
+New-Item -ItemType Directory -Force $HOME/.copilot | Out-Null
+@'
+CRITICAL: Pipe every non-interactive shell command through `distill` unless raw output is explicitly required.
+
+CRITICAL: Your prompt to `distill` must be fully explicit. State exactly what you want to know and exactly what the output must contain. If you want only filenames, say `Return only the filenames.` If you want JSON, say `Return valid JSON only.` Do not ask vague questions.
+
+Bad:
+- `distill "Which files are shown?"`
+
+Good:
+- `distill "Which files are shown? Return only the filenames."`
+
+Examples:
+- `bun test 2>&1 | distill "Did the tests pass? Return only: PASS or FAIL, followed by failing test names if any."`
+- `git diff 2>&1 | distill "What changed? Return only the files changed and a one-line summary for each file."`
+- `terraform plan 2>&1 | distill "Is this safe? Return only: SAFE, REVIEW, or UNSAFE, followed by the exact risky changes."`
+- `npm audit 2>&1 | distill "Extract the vulnerabilities. Return valid JSON only."`
+- `rg -n "TODO|FIXME" . 2>&1 | distill "List files containing TODO or FIXME. Return only file paths, one per line."`
+- `ls -la 2>&1 | distill "Which files are shown? Return only the filenames."`
+
+You may skip `distill` only in these cases:
+- Exact uncompressed output is required.
+- Using `distill` would break an interactive or TUI workflow.
+
+CRITICAL: Wait for `distill` to finish before continuing.
+'@ | Set-Content $HOME/.copilot/copilot-instructions.md
+```
+
+GitHub Copilot CLI also reads repository instructions from `.github/copilot-instructions.md`, and it can read `AGENTS.md` files from directories listed in `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`.
 
 ## Usage
 
@@ -78,6 +115,8 @@ distill config provider lmstudio
 distill config host http://127.0.0.1:1234/v1
 ```
 
+On Windows, the default config path is `%APPDATA%\distill\config.json` unless `DISTILL_CONFIG_PATH` is set.
+
 Supported providers:
 
 - `ollama`
@@ -104,6 +143,7 @@ Interactive prompts are passed through when `distill` detects simple prompt patt
 
 If you want Codex, Claude Code, or OpenCode to prefer `distill` whenever they run a command whose output will be sent to a paid LLM, add a global instruction telling the agent to pipe command output through `distill`.
 
+- GitHub Copilot CLI reads local global instructions from `$HOME/.copilot/copilot-instructions.md`.
 - Codex reads global agent instructions from `~/.codex/AGENTS.md`.
 - Claude Code supports global settings in `~/.claude/settings.json`, and its official mechanism for custom behavior is global instructions via `CLAUDE.md`.
 - OpenCode supports global instruction files through `~/.config/opencode/opencode.json`. Point its `instructions` field at a markdown file with the same rule.

--- a/packages/cli/bin/distill.js
+++ b/packages/cli/bin/distill.js
@@ -1,23 +1,40 @@
 #!/usr/bin/env node
 
 const { spawn } = require("node:child_process");
+const fs = require("node:fs");
 const path = require("node:path");
 const { createRequire } = require("node:module");
 
 const requireFromHere = createRequire(__filename);
 
 const PACKAGE_BY_TARGET = {
-  "darwin-arm64": "@samuelfaj/distill-darwin-arm64",
-  "darwin-x64": "@samuelfaj/distill-darwin-x64",
-  "linux-arm64": "@samuelfaj/distill-linux-arm64",
-  "linux-x64": "@samuelfaj/distill-linux-x64"
+  "darwin-arm64": {
+    packageName: "@samuelfaj/distill-darwin-arm64",
+    binaryName: "distill"
+  },
+  "darwin-x64": {
+    packageName: "@samuelfaj/distill-darwin-x64",
+    binaryName: "distill"
+  },
+  "linux-arm64": {
+    packageName: "@samuelfaj/distill-linux-arm64",
+    binaryName: "distill"
+  },
+  "linux-x64": {
+    packageName: "@samuelfaj/distill-linux-x64",
+    binaryName: "distill"
+  },
+  "win32-x64": {
+    packageName: "@samuelfaj/distill-win32-x64",
+    binaryName: "distill.exe"
+  }
 };
 
 function resolveBinaryPath() {
   const target = `${process.platform}-${process.arch}`;
-  const packageName = PACKAGE_BY_TARGET[target];
+  const targetSpec = PACKAGE_BY_TARGET[target];
 
-  if (!packageName) {
+  if (!targetSpec) {
     console.error(
       `[distill] Unsupported platform: ${process.platform}/${process.arch}.`
     );
@@ -25,11 +42,24 @@ function resolveBinaryPath() {
   }
 
   try {
-    const packageJsonPath = requireFromHere.resolve(`${packageName}/package.json`);
-    return path.join(path.dirname(packageJsonPath), "bin", "distill");
+    const packageJsonPath = requireFromHere.resolve(`${targetSpec.packageName}/package.json`);
+    return path.join(path.dirname(packageJsonPath), "bin", targetSpec.binaryName);
   } catch (error) {
+    const workspaceBinaryPath = path.resolve(
+      __dirname,
+      "..",
+      "..",
+      `distill-${target}`,
+      "bin",
+      targetSpec.binaryName
+    );
+
+    if (fs.existsSync(workspaceBinaryPath)) {
+      return workspaceBinaryPath;
+    }
+
     console.error(
-      `[distill] Missing platform package ${packageName}. Reinstall @samuelfaj/distill for this platform.`
+      `[distill] Missing platform package ${targetSpec.packageName}. Reinstall @samuelfaj/distill for this platform.`
     );
     process.exit(1);
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,8 @@
     "@samuelfaj/distill-darwin-arm64": "1.4.0",
     "@samuelfaj/distill-darwin-x64": "1.4.0",
     "@samuelfaj/distill-linux-arm64": "1.4.0",
-    "@samuelfaj/distill-linux-x64": "1.4.0"
+    "@samuelfaj/distill-linux-x64": "1.4.0",
+    "@samuelfaj/distill-win32-x64": "1.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/distill-win32-x64/package.json
+++ b/packages/distill-win32-x64/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@samuelfaj/distill-win32-x64",
+  "version": "1.4.0",
+  "license": "MIT",
+  "files": [
+    "bin/distill.exe"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/scripts/apply-platform-metadata.ts
+++ b/scripts/apply-platform-metadata.ts
@@ -22,6 +22,11 @@ const targets = [
     packagePath: "packages/distill-linux-x64/package.json",
     os: ["linux"],
     cpu: ["x64"]
+  },
+  {
+    packagePath: "packages/distill-win32-x64/package.json",
+    os: ["win32"],
+    cpu: ["x64"]
   }
 ] as const;
 

--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -4,27 +4,45 @@ import path from "node:path";
 
 const targets = [
   {
+    key: "darwin-arm64",
     bunTarget: "bun-darwin-arm64",
     output: ".dist/bun-darwin-arm64/distill"
   },
   {
+    key: "darwin-x64",
     bunTarget: "bun-darwin-x64",
     output: ".dist/bun-darwin-x64/distill"
   },
   {
+    key: "linux-arm64",
     bunTarget: "bun-linux-arm64",
     output: ".dist/bun-linux-arm64/distill"
   },
   {
+    key: "linux-x64",
     bunTarget: "bun-linux-x64",
     output: ".dist/bun-linux-x64/distill"
+  },
+  {
+    key: "win32-x64",
+    bunTarget: "bun-windows-x64",
+    output: ".dist/bun-windows-x64/distill.exe"
   }
 ] as const;
 
 const root = path.resolve(import.meta.dir, "..");
 const entrypoint = path.join(root, "src", "cli.ts");
+const currentTargetKey = `${process.platform}-${process.arch}`;
+const selectedTargets =
+  process.env.DISTILL_BUILD_ALL === "1"
+    ? targets
+    : targets.filter((target) => target.key === currentTargetKey);
 
-for (const target of targets) {
+if (selectedTargets.length === 0) {
+  throw new Error(`Unsupported build target for this machine: ${currentTargetKey}.`);
+}
+
+for (const target of selectedTargets) {
   const outfile = path.join(root, target.output);
   await mkdir(path.dirname(outfile), { recursive: true });
 

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -3,20 +3,26 @@ import path from "node:path";
 
 const root = path.resolve(import.meta.dir, "..");
 const requirePublishMetadata = Bun.argv.includes("--publish");
+const currentPlatformKey = `${process.platform}-${process.arch}`;
 const workspacePackages = [
   "packages/cli/package.json",
   "packages/distill-darwin-arm64/package.json",
   "packages/distill-darwin-x64/package.json",
   "packages/distill-linux-arm64/package.json",
-  "packages/distill-linux-x64/package.json"
+  "packages/distill-linux-x64/package.json",
+  "packages/distill-win32-x64/package.json"
 ];
 
-const binaries = [
-  "packages/distill-darwin-arm64/bin/distill",
-  "packages/distill-darwin-x64/bin/distill",
-  "packages/distill-linux-arm64/bin/distill",
-  "packages/distill-linux-x64/bin/distill"
-];
+const binariesByPlatform: Record<string, string> = {
+  "darwin-arm64": "packages/distill-darwin-arm64/bin/distill",
+  "darwin-x64": "packages/distill-darwin-x64/bin/distill",
+  "linux-arm64": "packages/distill-linux-arm64/bin/distill",
+  "linux-x64": "packages/distill-linux-x64/bin/distill",
+  "win32-x64": "packages/distill-win32-x64/bin/distill.exe"
+};
+const binaries = requirePublishMetadata
+  ? Object.values(binariesByPlatform)
+  : [binariesByPlatform[currentPlatformKey]].filter(Boolean);
 
 const manifests = await Promise.all(
   workspacePackages.map(async (relativePath) => {
@@ -33,6 +39,10 @@ if (versions.size !== 1) {
 
 for (const binary of binaries) {
   await access(path.join(root, binary));
+}
+
+if (binaries.length === 0) {
+  throw new Error(`Unsupported platform for release check: ${currentPlatformKey}`);
 }
 
 const cliManifest = manifests[0];

--- a/scripts/smoke-packages.ts
+++ b/scripts/smoke-packages.ts
@@ -8,6 +8,7 @@ import cliPackage from "../packages/cli/package.json";
 const root = path.resolve(import.meta.dir, "..");
 const packDir = await mkdtemp(path.join(tmpdir(), "distill-pack-"));
 const installDir = await mkdtemp(path.join(tmpdir(), "distill-install-"));
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 
 const currentPlatformPackage = (() => {
   const key = `${process.platform}-${process.arch}`;
@@ -15,7 +16,8 @@ const currentPlatformPackage = (() => {
     "darwin-arm64": "@samuelfaj/distill-darwin-arm64",
     "darwin-x64": "@samuelfaj/distill-darwin-x64",
     "linux-arm64": "@samuelfaj/distill-linux-arm64",
-    "linux-x64": "@samuelfaj/distill-linux-x64"
+    "linux-x64": "@samuelfaj/distill-linux-x64",
+    "win32-x64": "@samuelfaj/distill-win32-x64"
   };
 
   const value = mapping[key];
@@ -50,17 +52,26 @@ function runOrThrow(command: string, args: string[], cwd: string, env?: NodeJS.P
   return result.stdout.trim();
 }
 
+function resolveInstalledShimPath(installDir: string): string {
+  return path.join(
+    installDir,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "distill.cmd" : "distill"
+  );
+}
+
 try {
-  runOrThrow("npm", ["pack", "--workspace", currentPlatformPackage, "--pack-destination", packDir], root);
-  runOrThrow("npm", ["pack", "--workspace", "@samuelfaj/distill", "--pack-destination", packDir], root);
-  runOrThrow("npm", ["init", "-y"], installDir);
+  runOrThrow(npmCommand, ["pack", "--workspace", currentPlatformPackage, "--pack-destination", packDir], root);
+  runOrThrow(npmCommand, ["pack", "--workspace", "@samuelfaj/distill", "--pack-destination", packDir], root);
+  runOrThrow(npmCommand, ["init", "-y"], installDir);
 
   const tarballs = readdirSync(packDir)
     .sort()
     .map((entry) => path.join(packDir, entry));
-  runOrThrow("npm", ["install", ...tarballs], installDir);
+  runOrThrow(npmCommand, ["install", ...tarballs], installDir);
 
-  const shimPath = path.join(installDir, "node_modules", ".bin", "distill");
+  const shimPath = resolveInstalledShimPath(installDir);
   const versionOutput = runOrThrow(shimPath, ["--version"], installDir);
 
   if (versionOutput !== cliPackage.version) {
@@ -71,6 +82,7 @@ try {
     cwd: installDir,
     env: {
       ...process.env,
+      DISTILL_PROVIDER: "ollama",
       OLLAMA_HOST: "http://127.0.0.1:9"
     },
     encoding: "utf8",

--- a/scripts/sync-platform-packages.ts
+++ b/scripts/sync-platform-packages.ts
@@ -3,31 +3,52 @@ import path from "node:path";
 
 const targets = [
   {
+    key: "darwin-arm64",
     source: ".dist/bun-darwin-arm64/distill",
     destination: "packages/distill-darwin-arm64/bin/distill"
   },
   {
+    key: "darwin-x64",
     source: ".dist/bun-darwin-x64/distill",
     destination: "packages/distill-darwin-x64/bin/distill"
   },
   {
+    key: "linux-arm64",
     source: ".dist/bun-linux-arm64/distill",
     destination: "packages/distill-linux-arm64/bin/distill"
   },
   {
+    key: "linux-x64",
     source: ".dist/bun-linux-x64/distill",
     destination: "packages/distill-linux-x64/bin/distill"
+  },
+  {
+    key: "win32-x64",
+    source: ".dist/bun-windows-x64/distill.exe",
+    destination: "packages/distill-win32-x64/bin/distill.exe"
   }
 ] as const;
 
 const root = path.resolve(import.meta.dir, "..");
+const currentTargetKey = `${process.platform}-${process.arch}`;
+const selectedTargets =
+  process.env.DISTILL_BUILD_ALL === "1"
+    ? targets
+    : targets.filter((target) => target.key === currentTargetKey);
 
-for (const target of targets) {
+if (selectedTargets.length === 0) {
+  throw new Error(`Unsupported sync target for this machine: ${currentTargetKey}.`);
+}
+
+for (const target of selectedTargets) {
   const source = path.join(root, target.source);
   const destination = path.join(root, target.destination);
 
   await stat(source);
   await mkdir(path.dirname(destination), { recursive: true });
   await copyFile(source, destination);
-  await chmod(destination, 0o755);
+
+  if (!destination.endsWith(".exe")) {
+    await chmod(destination, 0o755);
+  }
 }

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -4,10 +4,27 @@ import path from "node:path";
 import type { ConfigKey, PersistedConfig } from "./config";
 
 function resolveConfigBaseDir(env: NodeJS.ProcessEnv): string {
+  const localAppData = env.LOCALAPPDATA?.trim();
+
+  if (localAppData) {
+    return path.join(localAppData, "distill");
+  }
+
+  const appData = env.APPDATA?.trim();
+
+  if (appData) {
+    return path.join(appData, "distill");
+  }
   const xdg = env.XDG_CONFIG_HOME?.trim();
 
   if (xdg) {
     return path.join(xdg, "distill");
+  }
+
+  const userProfile = env.USERPROFILE?.trim();
+
+  if (userProfile) {
+    return path.join(userProfile, "AppData", "Roaming", "distill");
   }
 
   const home = env.HOME?.trim();

--- a/test/cli-entry.test.ts
+++ b/test/cli-entry.test.ts
@@ -7,6 +7,7 @@ import cliPackage from "../packages/cli/package.json";
 
 const root = path.resolve(import.meta.dir, "..");
 const cli = path.join(root, "src", "cli.ts");
+const itUnixOnly = process.platform === "win32" ? it.skip : it;
 
 describe("cli entrypoint", () => {
   it("prints help", () => {
@@ -29,7 +30,7 @@ describe("cli entrypoint", () => {
     expect(result.stdout.trim()).toBe(cliPackage.version);
   });
 
-  it("fails without stdin when attached to a tty", () => {
+  itUnixOnly("fails without stdin when attached to a tty", () => {
     const result = spawnSync(
       "script",
       ["-q", "/dev/null", "bun", "run", cli, "is this safe?"],

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -12,21 +12,24 @@ import { spawn, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-setDefaultTimeout(60_000);
+setDefaultTimeout(process.platform === "win32" ? 120_000 : 60_000);
 
 const root = path.resolve(import.meta.dir, "..");
 const launcher = path.join(root, "packages", "cli", "bin", "distill.js");
-const expectedVersion = "1.4.0";
+const expectedVersion = cliPackage.version;
 const WATCH_IDLE_MS = 1_800;
 const WATCH_START_DELAY_MS = 600;
 const INTERACTIVE_DELAY_MS = 1_000;
+const itUnixOnly = process.platform === "win32" ? it.skip : it;
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const currentPlatformPackage = (() => {
   const key = `${process.platform}-${process.arch}`;
   const mapping: Record<string, string> = {
     "darwin-arm64": "@samuelfaj/distill-darwin-arm64",
     "darwin-x64": "@samuelfaj/distill-darwin-x64",
     "linux-arm64": "@samuelfaj/distill-linux-arm64",
-    "linux-x64": "@samuelfaj/distill-linux-x64"
+    "linux-x64": "@samuelfaj/distill-linux-x64",
+    "win32-x64": "@samuelfaj/distill-win32-x64"
   };
 
   const value = mapping[key];
@@ -37,6 +40,33 @@ const currentPlatformPackage = (() => {
 
   return value;
 })();
+
+function createOllamaEnv(host: string, env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    DISTILL_PROVIDER: "ollama",
+    OLLAMA_HOST: host
+  };
+}
+
+function resolveInstalledShimPath(installDir: string): string {
+  return path.join(
+    installDir,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "distill.cmd" : "distill"
+  );
+}
+
+function resolveInstalledBinaryPath(installDir: string): string {
+  return path.join(
+    installDir,
+    "node_modules",
+    ...currentPlatformPackage.split("/"),
+    "bin",
+    process.platform === "win32" ? "distill.exe" : "distill"
+  );
+}
 
 interface InputStep {
   afterMs?: number;
@@ -84,16 +114,21 @@ function runOrThrow(
   return result.stdout.trim();
 }
 
-async function runLauncher(args: string[], options?: {
-  env?: NodeJS.ProcessEnv;
-  inputSteps?: InputStep[];
-  finalDelayMs?: number;
-}): Promise<RunResult> {
-  const child = spawn("node", [launcher, ...args], {
-    cwd: root,
+async function runProcess(
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+    inputSteps?: InputStep[];
+    finalDelayMs?: number;
+  }
+): Promise<RunResult> {
+  const child = spawn(command, args, {
+    cwd: options.cwd,
     env: {
       ...process.env,
-      ...options?.env
+      ...options.env
     },
     stdio: ["pipe", "pipe", "pipe"]
   });
@@ -110,7 +145,7 @@ async function runLauncher(args: string[], options?: {
   });
 
   const writer = (async () => {
-    for (const step of options?.inputSteps ?? []) {
+    for (const step of options.inputSteps ?? []) {
       await delay(step.afterMs ?? 0);
 
       if (!child.stdin.destroyed && !child.killed) {
@@ -118,7 +153,7 @@ async function runLauncher(args: string[], options?: {
       }
     }
 
-    await delay(options?.finalDelayMs ?? 0);
+    await delay(options.finalDelayMs ?? 0);
 
     if (!child.stdin.destroyed && !child.killed) {
       child.stdin.end();
@@ -128,17 +163,25 @@ async function runLauncher(args: string[], options?: {
   const exit = new Promise<RunResult>((resolve, reject) => {
     child.on("error", reject);
     child.on("close", (code, signal) => {
-      resolve({
-        code,
-        signal,
-        stdout,
-        stderr
-      });
+      resolve({ code, signal, stdout, stderr });
     });
   });
 
   await writer;
   return exit;
+}
+
+async function runLauncher(args: string[], options?: {
+  env?: NodeJS.ProcessEnv;
+  inputSteps?: InputStep[];
+  finalDelayMs?: number;
+}): Promise<RunResult> {
+  return runProcess("node", [launcher, ...args], {
+    cwd: root,
+    env: options?.env,
+    inputSteps: options?.inputSteps,
+    finalDelayMs: options?.finalDelayMs
+  });
 }
 
 async function createFakeOllama(
@@ -182,7 +225,7 @@ function normalizePtyOutput(output: string): string {
 }
 
 beforeAll(() => {
-  runOrThrow("npm", ["run", "build"], root);
+  runOrThrow(npmCommand, ["run", "build"], root);
 });
 
 describe("distill end-to-end", () => {
@@ -195,9 +238,7 @@ describe("distill end-to-end", () => {
 
     try {
       const result = await runLauncher(["did the tests pass?"], {
-        env: {
-          OLLAMA_HOST: fake.host
-        },
+        env: createOllamaEnv(fake.host),
         inputSteps: [{ data: "Ran 12 tests\n12 passed\n" }]
       });
 
@@ -215,7 +256,7 @@ describe("distill end-to-end", () => {
     }
   });
 
-  it("keeps the spinner moving in a pty while collecting streamed input and summarizing", async () => {
+  itUnixOnly("keeps the spinner moving in a pty while collecting streamed input and summarizing", async () => {
     const fake = await createFakeOllama(async (_body, _index) => {
       await delay(700);
       return new Response(JSON.stringify({ response: "All tests passed." }), {
@@ -233,9 +274,7 @@ describe("distill end-to-end", () => {
         "script",
         ["-q", capturePath, "zsh", "-lc", shellCommand],
         root,
-        {
-          OLLAMA_HOST: fake.host
-        }
+        createOllamaEnv(fake.host)
       );
 
       const output = normalizePtyOutput(await readFile(capturePath, "utf8"));
@@ -284,9 +323,7 @@ describe("distill end-to-end", () => {
 
     try {
       const result = await runLauncher(["what changed?"], {
-        env: {
-          OLLAMA_HOST: fake.host
-        },
+        env: createOllamaEnv(fake.host),
         inputSteps: [
           { afterMs: WATCH_START_DELAY_MS, data: "watch run\r\nfailures: 0\n" },
           { afterMs: WATCH_IDLE_MS, data: "watch run\nfailures: 1\n" }
@@ -313,9 +350,7 @@ describe("distill end-to-end", () => {
 
     try {
       const result = await runLauncher(["confirm the action"], {
-        env: {
-          OLLAMA_HOST: fake.host
-        },
+        env: createOllamaEnv(fake.host),
         inputSteps: [
           { data: "Continue? [y/N]" },
           { afterMs: INTERACTIVE_DELAY_MS, data: "\ny\n" }
@@ -343,47 +378,47 @@ describe("distill end-to-end", () => {
 
     try {
       runOrThrow(
-        "npm",
+        npmCommand,
         ["pack", "--workspace", currentPlatformPackage, "--pack-destination", packDir],
         root
       );
       runOrThrow(
-        "npm",
+        npmCommand,
         ["pack", "--workspace", "@samuelfaj/distill", "--pack-destination", packDir],
         root
       );
-      runOrThrow("npm", ["init", "-y"], installDir);
+      runOrThrow(npmCommand, ["init", "-y"], installDir);
 
       const tarballs = readdirSync(packDir)
         .sort()
         .map((entry) => path.join(packDir, entry));
-      runOrThrow("npm", ["install", ...tarballs], installDir);
+      runOrThrow(npmCommand, ["install", ...tarballs], installDir);
 
-      const version = runOrThrow(
-        path.join(installDir, "node_modules", ".bin", "distill"),
-        ["--version"],
-        installDir
-      );
-      expect(version).toBe(expectedVersion);
+      const installedShim = resolveInstalledShimPath(installDir);
+      const version = await runProcess(installedShim, ["--version"], {
+        cwd: installDir
+      });
+      expect(version.code).toBe(0);
+      expect(version.stderr).toBe("");
+      expect(version.stdout.trim()).toBe(expectedVersion);
 
-      const summary = runOrThrow(
-        path.join(installDir, "node_modules", ".bin", "distill"),
-        ["did the tests pass?"],
-        installDir,
-        {
-          OLLAMA_HOST: fake.host
-        },
-        "12 passed\n"
-      );
+      const installedBinary = resolveInstalledBinaryPath(installDir);
+      const summary = await runProcess(installedBinary, ["did the tests pass?"], {
+        cwd: installDir,
+        env: createOllamaEnv(fake.host),
+        inputSteps: [{ data: "12 passed\n" }]
+      });
 
-      expect(summary).toBe("Tests passed.");
+      expect(summary.code).toBe(0);
+      expect(summary.stderr).toBe("");
+      expect(summary.stdout.trim()).toBe("Tests passed.");
       expect(fake.requests).toHaveLength(1);
     } finally {
       fake.stop();
       await rm(packDir, { recursive: true, force: true });
       await rm(installDir, { recursive: true, force: true });
     }
-  });
+  }, process.platform === "win32" ? 300_000 : undefined);
 
   it("persists model and thinking config through the launcher", async () => {
     const fake = await createFakeOllama((_body, _index) =>
@@ -410,6 +445,7 @@ describe("distill end-to-end", () => {
       const result = await runLauncher(["summarize"], {
         env: {
           DISTILL_CONFIG_PATH: configPath,
+          DISTILL_PROVIDER: "ollama",
           OLLAMA_HOST: fake.host
         },
         inputSteps: [{ data: "all good\n" }]

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -4,8 +4,9 @@ import path from "node:path";
 
 const root = path.resolve(import.meta.dir, "..");
 const cli = path.join(root, "src", "cli.ts");
+const describeUnixOnly = process.platform === "win32" ? describe.skip : describe;
 
-describe("pipeline exit behavior", () => {
+describeUnixOnly("pipeline exit behavior", () => {
   it("mirrors the upstream exit with pipefail", () => {
     const result = spawnSync(
       "bash",

--- a/test/user-config.test.ts
+++ b/test/user-config.test.ts
@@ -42,6 +42,8 @@ describe("user config", () => {
   });
 
   it("resolves config path from xdg or explicit path", () => {
+    const appData = "C:\\Users\\me\\AppData\\Roaming";
+
     expect(
       resolveConfigPath({
         DISTILL_CONFIG_PATH: "/tmp/custom-distill.json"
@@ -52,6 +54,12 @@ describe("user config", () => {
       resolveConfigPath({
         XDG_CONFIG_HOME: "/tmp/xdg"
       })
-    ).toBe("/tmp/xdg/distill/config.json");
+    ).toBe(path.join("/tmp/xdg", "distill", "config.json"));
+
+    expect(
+      resolveConfigPath({
+        APPDATA: appData
+      })
+    ).toBe(path.join(appData, "distill", "config.json"));
   });
 });


### PR DESCRIPTION
This pull request adds Windows x64 support to the `distill` CLI and platform packages, updates build and release scripts to handle Windows, and improves documentation and configuration for cross-platform compatibility. It also updates tests and smoke scripts to ensure Windows compatibility and clarifies configuration paths on Windows.

**Platform support:**

* Added the `@samuelfaj/distill-win32-x64` package for Windows x64, including necessary changes to `packages/cli/package.json`, platform metadata, build, sync, and release scripts to support Windows binaries. [[1]](diffhunk://#diff-7505c2d3a127663d742b28511b4fc0e8d41060f36a74e22896b988f088ae5c67R1-R11) [[2]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L20-R21) [[3]](diffhunk://#diff-d3f6c250e84a26023572b9ed2196ecc763121fa19862e6aa5f6850fbe0a004caR25-R29) [[4]](diffhunk://#diff-c43b36d73843230000d86893b56910dca8d15e2231c518c4d0829e3cbf0c10afR7-R45) [[5]](diffhunk://#diff-6780c76c442751195621df13431ed2f00e23a5f8cd3fcb243b648a54e2d207c7R6-R54) [[6]](diffhunk://#diff-7442dde11cc7eab16ed7c0b22b5f99720d6f61d117a29eab75a65dd6d322dae1R6-R25) [[7]](diffhunk://#diff-7442dde11cc7eab16ed7c0b22b5f99720d6f61d117a29eab75a65dd6d322dae1R44-R47)
* Updated smoke test and end-to-end test scripts to use `npm.cmd` and `.cmd`/`.exe` shims on Windows, and to include Windows platform package mappings. [[1]](diffhunk://#diff-1472ca657404c5560972f0d62a1cc7bf7773a1b889e62b4e512ac2fa1a1b8132R11-R20) [[2]](diffhunk://#diff-1472ca657404c5560972f0d62a1cc7bf7773a1b889e62b4e512ac2fa1a1b8132R55-R74) [[3]](diffhunk://#diff-1472ca657404c5560972f0d62a1cc7bf7773a1b889e62b4e512ac2fa1a1b8132R85) [[4]](diffhunk://#diff-e89570ca6b6f738bc439efe735c216bb8c7c9964bb1ab5b44c0ef6ab8538c92eL15-R32) [[5]](diffhunk://#diff-e89570ca6b6f738bc439efe735c216bb8c7c9964bb1ab5b44c0ef6ab8538c92eR44-R70) [[6]](diffhunk://#diff-e89570ca6b6f738bc439efe735c216bb8c7c9964bb1ab5b44c0ef6ab8538c92eL87-R131) [[7]](diffhunk://#diff-e89570ca6b6f738bc439efe735c216bb8c7c9964bb1ab5b44c0ef6ab8538c92eL113-R156) [[8]](diffhunk://#diff-e89570ca6b6f738bc439efe735c216bb8c7c9964bb1ab5b44c0ef6ab8538c92eL131-R186) [[9]](diffhunk://#diff-e89570ca6b6f738bc439efe735c216bb8c7c9964bb1ab5b44c0ef6ab8538c92eL185-R228) [[10]](diffhunk://#diff-e89570ca6b6f738bc439efe735c216bb8c7c9964bb1ab5b44c0ef6ab8538c92eL198-R241)

**Configuration and documentation:**

* Updated `README.md` to document Windows support, clarify config paths, and provide PowerShell examples for GitHub Copilot CLI global instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R83) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118-R119) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R146)
* Improved config path resolution in `src/user-config.ts` to handle Windows-specific environment variables (`LOCALAPPDATA`, `APPDATA`, `USERPROFILE`).

**Testing improvements:**

* Adjusted CLI and e2e tests to skip Unix-only tests on Windows and increased timeout for Windows runs. [[1]](diffhunk://#diff-79ca7a29f32996d9c47a1bf035f19ae9d47c5b70381262efc3cbed7b5fceacbdR10) [[2]](diffhunk://#diff-79ca7a29f32996d9c47a1bf035f19ae9d47c5b70381262efc3cbed7b5fceacbdL32-R33) [[3]](diffhunk://#diff-e89570ca6b6f738bc439efe735c216bb8c7c9964bb1ab5b44c0ef6ab8538c92eL15-R32)

These changes ensure robust cross-platform support, especially for Windows users, and improve installation, configuration, and testing workflows.…ntation