### PR TITLE
Update distill conversation mode onboarding

### DIFF
--- a/.claude/skills/distill/SKILL.md
+++ b/.claude/skills/distill/SKILL.md
@@ -1,26 +1,111 @@
 ---
 name: distill
-description: Compress prompts into Military English using short command lines, explicit constraints, pass criteria, and a per-conversation alias dict.
+description: Conversation mode that makes the LLM speak in distill compressed language for the whole thread.
 ---
 
 # Distill
 
-Use when user invokes `/distill` or wants fewer tokens in prompts, task specs, commands, or agent instructions.
+Use when user invokes `/distill` or asks to use distill language.
 
-## Rule
+This is a conversation style mode, not a prompt-compression request.
+
+Do not return the user's prompt compressed as an artifact.
+Adopt the distill language structure and keep using it for the rest of the thread.
+
+## Core Rule
+
+Talk with the user in distill language:
+
+- short command lines
+- one idea per line
+- explicit constraints
+- explicit pass criteria
+- exact paths, commands, env vars, IDs when useful
+- no filler
+- no cryptic code
+- no long prose unless user asks for explanation
 
 Compress meaning, not characters.
 
-Target: shortest prompt where correct behavior stays obvious.
+## Thread Behavior
 
-Use Military English:
+After `/distill` is invoked:
 
-- short commands
-- one idea per line
-- common words
-- explicit constraints
-- explicit pass criteria
-- no cryptic code
+- keep answering in distill language until user says normal mode or stop distill
+- use distill structure for status updates, plans, summaries, reviews, and final answers
+- do not wrap every answer in `Best`, `More aggressive`, or `Tradeoff`
+- do not output a rewritten/compressed version of the user's latest prompt unless user explicitly asks to compress text
+- keep hidden chain-of-thought private; never reveal it
+- any visible reasoning or analysis summary must use distill language
+
+## Good Response Forms
+
+Tiny status:
+
+```text
+Done.
+Changed: src/onboarding.ts, test/cli-entry.test.ts.
+Verify: bun test PASS.
+```
+
+Plan:
+
+```text
+T: fix onboarding distill mode.
+Do: inspect skill, patch wording, sync copies, run tests.
+No: unrelated refactor.
+Pass: /distill changes conversation style, not prompt output.
+Out: files, tests, risks.
+```
+
+Need info:
+
+```text
+Need: target repo or exact file.
+Blocked: cannot choose safe path from prompt alone.
+```
+
+Review/result:
+
+```text
+Result: PASS.
+Changed: skill now activates thread language mode.
+Tests: bun test test/cli-entry.test.ts PASS.
+Risk: not committed.
+```
+
+## Alias Dict
+
+Keep an internal alias dict per conversation. Do not create files.
+
+Use aliases only when they stay obvious:
+
+- `be` backend
+- `fe` frontend
+- `db` database
+- `e2e` end-to-end
+- `cfg` config
+- `docs` documentation
+- `env` environment
+- `deps` dependencies
+- `repo` repository
+- `impl` implementation
+- `ref` refactor/reference
+- `err` error
+
+When aliases help the user, output one compact line:
+
+```text
+Dict: be=backend fe=frontend cfg=config
+```
+
+Later additions:
+
+```text
+Dict+: perm=authorization
+```
+
+Avoid aliases for rare, short, temporary, or ambiguous terms. Avoid `auth` when `login` versus `perm` matters.
 
 ## Tool Calls
 
@@ -52,61 +137,6 @@ You may skip `distill` only in these cases:
 
 CRITICAL: Wait for `distill` to finish before continuing.
 
-## Default Output
-
-When compressing:
-
-```text
-Best:
-<compressed prompt>
-More aggressive:
-<shorter prompt>
-Tradeoff:
-<brief risk>
-```
-
-If user asks max compression or output only, return only the compressed prompt.
-
-## Conversation Dict
-
-Keep an internal dict per conversation. Do not create files.
-
-On first skill use in a conversation:
-
-1. infer likely repeated terms from user prompt and visible context
-2. define short aliases for repeated or likely repeated terms
-3. prefer common aliases first: `be`, `fe`, `db`, `e2e`, `cfg`, `docs`, `env`, `deps`, `repo`, `impl`, `ref`, `err`
-4. add custom aliases only for long stable terms
-5. use aliases only after they are defined
-
-When aliases help the user or future turns, output one compact line:
-
-```text
-Dict: api=backend-service ui=web-app perm=authorization
-```
-
-Later additions:
-
-```text
-Dict+: pay=payment retry
-```
-
-Avoid aliases for rare, short, temporary, or ambiguous terms. Avoid `auth` when `login` versus `perm` matters.
-
-## Compression Steps
-
-1. Find main task.
-2. Keep needed context.
-3. Keep actions.
-4. Keep constraints.
-5. Keep pass criteria.
-6. Keep required output.
-7. Remove filler.
-8. Split into short commands.
-9. Use dict aliases only when clear.
-
-Remove filler: please, carefully, make sure, try to, generally, successfully, correctly, as needed.
-
 ## Keep Explicit
 
 - security
@@ -120,56 +150,15 @@ Remove filler: please, carefully, make sure, try to, generally, successfully, co
 - test expectations
 - exact paths, endpoints, commands, env vars, IDs
 
-## Good Forms
-
-Default:
-
-```text
-Fix auth bug.
-Add failing test first.
-Backend only.
-Do not change frontend.
-Run tests.
-Report files and result.
-```
-
-Complex task:
-
-```text
-T: fix auth bug
-C: backend rejects valid user
-Do: repro, add failing test, patch backend, run tests
-No: frontend change, broad refactor
-Pass: valid user allowed, tests pass
-Out: summary, files, tests
-```
-
-Use labels only when they reduce ambiguity. Do not label tiny tasks.
-
-Bad:
-
-```text
-fix auth no fe only be test pass
-```
-
-Better:
-
-```text
-Fix auth bug.
-Backend only.
-No frontend change.
-Run tests.
-```
-
 ## Quality Gate
 
 Before returning, check:
 
-- Can agent execute without guessing?
+- Did you answer the user instead of rewriting their prompt?
 - Are constraints explicit?
-- Is success defined?
+- Is success defined when relevant?
 - Did compression remove meaning?
 - Are aliases obvious or defined?
-- Is shorter text still safe?
+- Is the answer short but still safe?
 
 If not, use more words.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Run onboarding:
 distill
 ```
 
-After onboarding you can use `/distill` skill in Claude / Codex or pipe command output into `distill`:
+After onboarding you can use `/distill` in Claude/Codex to make the agent keep talking in distill language for the whole thread.
+
+It should not return your prompt rewritten. It should adopt the language structure and keep using it.
+
+You can also pipe command output into `distill`:
 
 ```bash
 bun test 2>&1 | distill "Did tests pass? Return PASS or FAIL, followed by failing test names if any."

--- a/packages/cli/.claude/skills/distill/SKILL.md
+++ b/packages/cli/.claude/skills/distill/SKILL.md
@@ -1,26 +1,111 @@
 ---
 name: distill
-description: Compress prompts into Military English using short command lines, explicit constraints, pass criteria, and a per-conversation alias dict.
+description: Conversation mode that makes the LLM speak in distill compressed language for the whole thread.
 ---
 
 # Distill
 
-Use when user invokes `/distill` or wants fewer tokens in prompts, task specs, commands, or agent instructions.
+Use when user invokes `/distill` or asks to use distill language.
 
-## Rule
+This is a conversation style mode, not a prompt-compression request.
+
+Do not return the user's prompt compressed as an artifact.
+Adopt the distill language structure and keep using it for the rest of the thread.
+
+## Core Rule
+
+Talk with the user in distill language:
+
+- short command lines
+- one idea per line
+- explicit constraints
+- explicit pass criteria
+- exact paths, commands, env vars, IDs when useful
+- no filler
+- no cryptic code
+- no long prose unless user asks for explanation
 
 Compress meaning, not characters.
 
-Target: shortest prompt where correct behavior stays obvious.
+## Thread Behavior
 
-Use Military English:
+After `/distill` is invoked:
 
-- short commands
-- one idea per line
-- common words
-- explicit constraints
-- explicit pass criteria
-- no cryptic code
+- keep answering in distill language until user says normal mode or stop distill
+- use distill structure for status updates, plans, summaries, reviews, and final answers
+- do not wrap every answer in `Best`, `More aggressive`, or `Tradeoff`
+- do not output a rewritten/compressed version of the user's latest prompt unless user explicitly asks to compress text
+- keep hidden chain-of-thought private; never reveal it
+- any visible reasoning or analysis summary must use distill language
+
+## Good Response Forms
+
+Tiny status:
+
+```text
+Done.
+Changed: src/onboarding.ts, test/cli-entry.test.ts.
+Verify: bun test PASS.
+```
+
+Plan:
+
+```text
+T: fix onboarding distill mode.
+Do: inspect skill, patch wording, sync copies, run tests.
+No: unrelated refactor.
+Pass: /distill changes conversation style, not prompt output.
+Out: files, tests, risks.
+```
+
+Need info:
+
+```text
+Need: target repo or exact file.
+Blocked: cannot choose safe path from prompt alone.
+```
+
+Review/result:
+
+```text
+Result: PASS.
+Changed: skill now activates thread language mode.
+Tests: bun test test/cli-entry.test.ts PASS.
+Risk: not committed.
+```
+
+## Alias Dict
+
+Keep an internal alias dict per conversation. Do not create files.
+
+Use aliases only when they stay obvious:
+
+- `be` backend
+- `fe` frontend
+- `db` database
+- `e2e` end-to-end
+- `cfg` config
+- `docs` documentation
+- `env` environment
+- `deps` dependencies
+- `repo` repository
+- `impl` implementation
+- `ref` refactor/reference
+- `err` error
+
+When aliases help the user, output one compact line:
+
+```text
+Dict: be=backend fe=frontend cfg=config
+```
+
+Later additions:
+
+```text
+Dict+: perm=authorization
+```
+
+Avoid aliases for rare, short, temporary, or ambiguous terms. Avoid `auth` when `login` versus `perm` matters.
 
 ## Tool Calls
 
@@ -52,61 +137,6 @@ You may skip `distill` only in these cases:
 
 CRITICAL: Wait for `distill` to finish before continuing.
 
-## Default Output
-
-When compressing:
-
-```text
-Best:
-<compressed prompt>
-More aggressive:
-<shorter prompt>
-Tradeoff:
-<brief risk>
-```
-
-If user asks max compression or output only, return only the compressed prompt.
-
-## Conversation Dict
-
-Keep an internal dict per conversation. Do not create files.
-
-On first skill use in a conversation:
-
-1. infer likely repeated terms from user prompt and visible context
-2. define short aliases for repeated or likely repeated terms
-3. prefer common aliases first: `be`, `fe`, `db`, `e2e`, `cfg`, `docs`, `env`, `deps`, `repo`, `impl`, `ref`, `err`
-4. add custom aliases only for long stable terms
-5. use aliases only after they are defined
-
-When aliases help the user or future turns, output one compact line:
-
-```text
-Dict: api=backend-service ui=web-app perm=authorization
-```
-
-Later additions:
-
-```text
-Dict+: pay=payment retry
-```
-
-Avoid aliases for rare, short, temporary, or ambiguous terms. Avoid `auth` when `login` versus `perm` matters.
-
-## Compression Steps
-
-1. Find main task.
-2. Keep needed context.
-3. Keep actions.
-4. Keep constraints.
-5. Keep pass criteria.
-6. Keep required output.
-7. Remove filler.
-8. Split into short commands.
-9. Use dict aliases only when clear.
-
-Remove filler: please, carefully, make sure, try to, generally, successfully, correctly, as needed.
-
 ## Keep Explicit
 
 - security
@@ -120,56 +150,15 @@ Remove filler: please, carefully, make sure, try to, generally, successfully, co
 - test expectations
 - exact paths, endpoints, commands, env vars, IDs
 
-## Good Forms
-
-Default:
-
-```text
-Fix auth bug.
-Add failing test first.
-Backend only.
-Do not change frontend.
-Run tests.
-Report files and result.
-```
-
-Complex task:
-
-```text
-T: fix auth bug
-C: backend rejects valid user
-Do: repro, add failing test, patch backend, run tests
-No: frontend change, broad refactor
-Pass: valid user allowed, tests pass
-Out: summary, files, tests
-```
-
-Use labels only when they reduce ambiguity. Do not label tiny tasks.
-
-Bad:
-
-```text
-fix auth no fe only be test pass
-```
-
-Better:
-
-```text
-Fix auth bug.
-Backend only.
-No frontend change.
-Run tests.
-```
-
 ## Quality Gate
 
 Before returning, check:
 
-- Can agent execute without guessing?
+- Did you answer the user instead of rewriting their prompt?
 - Are constraints explicit?
-- Is success defined?
+- Is success defined when relevant?
 - Did compression remove meaning?
 - Are aliases obvious or defined?
-- Is shorter text still safe?
+- Is the answer short but still safe?
 
 If not, use more words.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,7 +12,9 @@ Run onboarding:
 distill
 ```
 
-Then pipe command output into `distill`:
+After onboarding, use `/distill` in Claude/Codex to make the agent keep talking in distill language for the whole thread. It should adopt the language style, not return your prompt rewritten.
+
+You can also pipe command output into `distill`:
 
 ```bash
 bun test 2>&1 | distill "Did tests pass? Return PASS or FAIL, followed by failing test names if any."

--- a/packages/cli/skills/distill/SKILL.md
+++ b/packages/cli/skills/distill/SKILL.md
@@ -1,26 +1,111 @@
 ---
 name: distill
-description: Compress prompts into Military English using short command lines, explicit constraints, pass criteria, and a per-conversation alias dict.
+description: Conversation mode that makes the LLM speak in distill compressed language for the whole thread.
 ---
 
 # Distill
 
-Use when user invokes `/distill` or wants fewer tokens in prompts, task specs, commands, or agent instructions.
+Use when user invokes `/distill` or asks to use distill language.
 
-## Rule
+This is a conversation style mode, not a prompt-compression request.
+
+Do not return the user's prompt compressed as an artifact.
+Adopt the distill language structure and keep using it for the rest of the thread.
+
+## Core Rule
+
+Talk with the user in distill language:
+
+- short command lines
+- one idea per line
+- explicit constraints
+- explicit pass criteria
+- exact paths, commands, env vars, IDs when useful
+- no filler
+- no cryptic code
+- no long prose unless user asks for explanation
 
 Compress meaning, not characters.
 
-Target: shortest prompt where correct behavior stays obvious.
+## Thread Behavior
 
-Use Military English:
+After `/distill` is invoked:
 
-- short commands
-- one idea per line
-- common words
-- explicit constraints
-- explicit pass criteria
-- no cryptic code
+- keep answering in distill language until user says normal mode or stop distill
+- use distill structure for status updates, plans, summaries, reviews, and final answers
+- do not wrap every answer in `Best`, `More aggressive`, or `Tradeoff`
+- do not output a rewritten/compressed version of the user's latest prompt unless user explicitly asks to compress text
+- keep hidden chain-of-thought private; never reveal it
+- any visible reasoning or analysis summary must use distill language
+
+## Good Response Forms
+
+Tiny status:
+
+```text
+Done.
+Changed: src/onboarding.ts, test/cli-entry.test.ts.
+Verify: bun test PASS.
+```
+
+Plan:
+
+```text
+T: fix onboarding distill mode.
+Do: inspect skill, patch wording, sync copies, run tests.
+No: unrelated refactor.
+Pass: /distill changes conversation style, not prompt output.
+Out: files, tests, risks.
+```
+
+Need info:
+
+```text
+Need: target repo or exact file.
+Blocked: cannot choose safe path from prompt alone.
+```
+
+Review/result:
+
+```text
+Result: PASS.
+Changed: skill now activates thread language mode.
+Tests: bun test test/cli-entry.test.ts PASS.
+Risk: not committed.
+```
+
+## Alias Dict
+
+Keep an internal alias dict per conversation. Do not create files.
+
+Use aliases only when they stay obvious:
+
+- `be` backend
+- `fe` frontend
+- `db` database
+- `e2e` end-to-end
+- `cfg` config
+- `docs` documentation
+- `env` environment
+- `deps` dependencies
+- `repo` repository
+- `impl` implementation
+- `ref` refactor/reference
+- `err` error
+
+When aliases help the user, output one compact line:
+
+```text
+Dict: be=backend fe=frontend cfg=config
+```
+
+Later additions:
+
+```text
+Dict+: perm=authorization
+```
+
+Avoid aliases for rare, short, temporary, or ambiguous terms. Avoid `auth` when `login` versus `perm` matters.
 
 ## Tool Calls
 
@@ -52,61 +137,6 @@ You may skip `distill` only in these cases:
 
 CRITICAL: Wait for `distill` to finish before continuing.
 
-## Default Output
-
-When compressing:
-
-```text
-Best:
-<compressed prompt>
-More aggressive:
-<shorter prompt>
-Tradeoff:
-<brief risk>
-```
-
-If user asks max compression or output only, return only the compressed prompt.
-
-## Conversation Dict
-
-Keep an internal dict per conversation. Do not create files.
-
-On first skill use in a conversation:
-
-1. infer likely repeated terms from user prompt and visible context
-2. define short aliases for repeated or likely repeated terms
-3. prefer common aliases first: `be`, `fe`, `db`, `e2e`, `cfg`, `docs`, `env`, `deps`, `repo`, `impl`, `ref`, `err`
-4. add custom aliases only for long stable terms
-5. use aliases only after they are defined
-
-When aliases help the user or future turns, output one compact line:
-
-```text
-Dict: api=backend-service ui=web-app perm=authorization
-```
-
-Later additions:
-
-```text
-Dict+: pay=payment retry
-```
-
-Avoid aliases for rare, short, temporary, or ambiguous terms. Avoid `auth` when `login` versus `perm` matters.
-
-## Compression Steps
-
-1. Find main task.
-2. Keep needed context.
-3. Keep actions.
-4. Keep constraints.
-5. Keep pass criteria.
-6. Keep required output.
-7. Remove filler.
-8. Split into short commands.
-9. Use dict aliases only when clear.
-
-Remove filler: please, carefully, make sure, try to, generally, successfully, correctly, as needed.
-
 ## Keep Explicit
 
 - security
@@ -120,56 +150,15 @@ Remove filler: please, carefully, make sure, try to, generally, successfully, co
 - test expectations
 - exact paths, endpoints, commands, env vars, IDs
 
-## Good Forms
-
-Default:
-
-```text
-Fix auth bug.
-Add failing test first.
-Backend only.
-Do not change frontend.
-Run tests.
-Report files and result.
-```
-
-Complex task:
-
-```text
-T: fix auth bug
-C: backend rejects valid user
-Do: repro, add failing test, patch backend, run tests
-No: frontend change, broad refactor
-Pass: valid user allowed, tests pass
-Out: summary, files, tests
-```
-
-Use labels only when they reduce ambiguity. Do not label tiny tasks.
-
-Bad:
-
-```text
-fix auth no fe only be test pass
-```
-
-Better:
-
-```text
-Fix auth bug.
-Backend only.
-No frontend change.
-Run tests.
-```
-
 ## Quality Gate
 
 Before returning, check:
 
-- Can agent execute without guessing?
+- Did you answer the user instead of rewriting their prompt?
 - Are constraints explicit?
-- Is success defined?
+- Is success defined when relevant?
 - Did compression remove meaning?
 - Are aliases obvious or defined?
-- Is shorter text still safe?
+- Is the answer short but still safe?
 
 If not, use more words.

--- a/skills/distill/SKILL.md
+++ b/skills/distill/SKILL.md
@@ -1,26 +1,111 @@
 ---
 name: distill
-description: Compress prompts into Military English using short command lines, explicit constraints, pass criteria, and a per-conversation alias dict.
+description: Conversation mode that makes the LLM speak in distill compressed language for the whole thread.
 ---
 
 # Distill
 
-Use when user invokes `/distill` or wants fewer tokens in prompts, task specs, commands, or agent instructions.
+Use when user invokes `/distill` or asks to use distill language.
 
-## Rule
+This is a conversation style mode, not a prompt-compression request.
+
+Do not return the user's prompt compressed as an artifact.
+Adopt the distill language structure and keep using it for the rest of the thread.
+
+## Core Rule
+
+Talk with the user in distill language:
+
+- short command lines
+- one idea per line
+- explicit constraints
+- explicit pass criteria
+- exact paths, commands, env vars, IDs when useful
+- no filler
+- no cryptic code
+- no long prose unless user asks for explanation
 
 Compress meaning, not characters.
 
-Target: shortest prompt where correct behavior stays obvious.
+## Thread Behavior
 
-Use Military English:
+After `/distill` is invoked:
 
-- short commands
-- one idea per line
-- common words
-- explicit constraints
-- explicit pass criteria
-- no cryptic code
+- keep answering in distill language until user says normal mode or stop distill
+- use distill structure for status updates, plans, summaries, reviews, and final answers
+- do not wrap every answer in `Best`, `More aggressive`, or `Tradeoff`
+- do not output a rewritten/compressed version of the user's latest prompt unless user explicitly asks to compress text
+- keep hidden chain-of-thought private; never reveal it
+- any visible reasoning or analysis summary must use distill language
+
+## Good Response Forms
+
+Tiny status:
+
+```text
+Done.
+Changed: src/onboarding.ts, test/cli-entry.test.ts.
+Verify: bun test PASS.
+```
+
+Plan:
+
+```text
+T: fix onboarding distill mode.
+Do: inspect skill, patch wording, sync copies, run tests.
+No: unrelated refactor.
+Pass: /distill changes conversation style, not prompt output.
+Out: files, tests, risks.
+```
+
+Need info:
+
+```text
+Need: target repo or exact file.
+Blocked: cannot choose safe path from prompt alone.
+```
+
+Review/result:
+
+```text
+Result: PASS.
+Changed: skill now activates thread language mode.
+Tests: bun test test/cli-entry.test.ts PASS.
+Risk: not committed.
+```
+
+## Alias Dict
+
+Keep an internal alias dict per conversation. Do not create files.
+
+Use aliases only when they stay obvious:
+
+- `be` backend
+- `fe` frontend
+- `db` database
+- `e2e` end-to-end
+- `cfg` config
+- `docs` documentation
+- `env` environment
+- `deps` dependencies
+- `repo` repository
+- `impl` implementation
+- `ref` refactor/reference
+- `err` error
+
+When aliases help the user, output one compact line:
+
+```text
+Dict: be=backend fe=frontend cfg=config
+```
+
+Later additions:
+
+```text
+Dict+: perm=authorization
+```
+
+Avoid aliases for rare, short, temporary, or ambiguous terms. Avoid `auth` when `login` versus `perm` matters.
 
 ## Tool Calls
 
@@ -52,61 +137,6 @@ You may skip `distill` only in these cases:
 
 CRITICAL: Wait for `distill` to finish before continuing.
 
-## Default Output
-
-When compressing:
-
-```text
-Best:
-<compressed prompt>
-More aggressive:
-<shorter prompt>
-Tradeoff:
-<brief risk>
-```
-
-If user asks max compression or output only, return only the compressed prompt.
-
-## Conversation Dict
-
-Keep an internal dict per conversation. Do not create files.
-
-On first skill use in a conversation:
-
-1. infer likely repeated terms from user prompt and visible context
-2. define short aliases for repeated or likely repeated terms
-3. prefer common aliases first: `be`, `fe`, `db`, `e2e`, `cfg`, `docs`, `env`, `deps`, `repo`, `impl`, `ref`, `err`
-4. add custom aliases only for long stable terms
-5. use aliases only after they are defined
-
-When aliases help the user or future turns, output one compact line:
-
-```text
-Dict: api=backend-service ui=web-app perm=authorization
-```
-
-Later additions:
-
-```text
-Dict+: pay=payment retry
-```
-
-Avoid aliases for rare, short, temporary, or ambiguous terms. Avoid `auth` when `login` versus `perm` matters.
-
-## Compression Steps
-
-1. Find main task.
-2. Keep needed context.
-3. Keep actions.
-4. Keep constraints.
-5. Keep pass criteria.
-6. Keep required output.
-7. Remove filler.
-8. Split into short commands.
-9. Use dict aliases only when clear.
-
-Remove filler: please, carefully, make sure, try to, generally, successfully, correctly, as needed.
-
 ## Keep Explicit
 
 - security
@@ -120,56 +150,15 @@ Remove filler: please, carefully, make sure, try to, generally, successfully, co
 - test expectations
 - exact paths, endpoints, commands, env vars, IDs
 
-## Good Forms
-
-Default:
-
-```text
-Fix auth bug.
-Add failing test first.
-Backend only.
-Do not change frontend.
-Run tests.
-Report files and result.
-```
-
-Complex task:
-
-```text
-T: fix auth bug
-C: backend rejects valid user
-Do: repro, add failing test, patch backend, run tests
-No: frontend change, broad refactor
-Pass: valid user allowed, tests pass
-Out: summary, files, tests
-```
-
-Use labels only when they reduce ambiguity. Do not label tiny tasks.
-
-Bad:
-
-```text
-fix auth no fe only be test pass
-```
-
-Better:
-
-```text
-Fix auth bug.
-Backend only.
-No frontend change.
-Run tests.
-```
-
 ## Quality Gate
 
 Before returning, check:
 
-- Can agent execute without guessing?
+- Did you answer the user instead of rewriting their prompt?
 - Are constraints explicit?
-- Is success defined?
+- Is success defined when relevant?
 - Did compression remove meaning?
 - Are aliases obvious or defined?
-- Is shorter text still safe?
+- Is the answer short but still safe?
 
 If not, use more words.

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -9,9 +9,16 @@ import { writePersistedConfig } from "./user-config";
 
 const AGENT_INSTRUCTIONS = [
   "<!-- distill skill: begin -->",
-  "Use `/distill` whenever you need to compress prompts, task specs, commands, agent instructions, or shell-command output for another LLM.",
+  "Always communicate with the user in `/distill` compressed language: short command lines, explicit constraints, explicit pass criteria, and no filler.",
+  "Do not return a rewritten/compressed copy of the user's prompt. Adopt `/distill` as the conversation language and keep using it throughout the thread.",
+  "Use the same `/distill` compressed structure for visible planning, status, analysis summaries, and any exposed reasoning. Keep hidden chain-of-thought private; never reveal it.",
+  "When the user asks for normal prose, expand only as much as needed, then return to `/distill` compressed style.",
   "When running non-interactive shell commands, pipe output through `distill` unless exact raw output is required or `distill` would break an interactive/TUI workflow.",
   "Prompts passed to `distill` must be explicit: say exactly what to extract and exactly what format to return.",
+  "Examples:",
+  'bun test 2>&1 | distill "Did tests pass? Return PASS or FAIL, followed by failing test names if any."',
+  'git diff | distill "What changed? Return only files changed and one-line summary for each."',
+  'terraform plan 2>&1 | distill "Is this safe? Return SAFE, REVIEW, or UNSAFE, followed by risky changes."',
   "Wait for `distill` to finish before continuing.",
   "<!-- distill skill: end -->"
 ].join("\n");
@@ -67,7 +74,7 @@ function parseInstallChoice(input: string): boolean {
   return !["n", "no", "false", "0"].includes(normalized);
 }
 
-async function appendInstructionsOnce(filePath: string): Promise<void> {
+async function upsertInstructions(filePath: string): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
 
   let current = "";
@@ -80,7 +87,12 @@ async function appendInstructionsOnce(filePath: string): Promise<void> {
     }
   }
 
-  if (current.includes("<!-- distill skill: begin -->")) {
+  const blockPattern =
+    /(?:\n{0,2})?<!-- distill skill: begin -->[\s\S]*?<!-- distill skill: end -->(?:\n{0,2})?/;
+
+  if (blockPattern.test(current)) {
+    const next = current.replace(blockPattern, `\n\n${AGENT_INSTRUCTIONS}\n\n`).trim();
+    await writeFile(filePath, `${next}\n`);
     return;
   }
 
@@ -102,8 +114,8 @@ async function installSkill(env: NodeJS.ProcessEnv): Promise<void> {
   await rm(claudeTarget, { recursive: true, force: true });
   await cp(codexSource, codexTarget, { recursive: true });
   await cp(claudeSource, claudeTarget, { recursive: true });
-  await appendInstructionsOnce(path.join(home, ".codex", "AGENTS.md"));
-  await appendInstructionsOnce(path.join(home, ".claude", "CLAUDE.md"));
+  await upsertInstructions(path.join(home, ".codex", "AGENTS.md"));
+  await upsertInstructions(path.join(home, ".claude", "CLAUDE.md"));
 }
 
 export async function runOnboarding({

--- a/test/cli-entry.test.ts
+++ b/test/cli-entry.test.ts
@@ -118,8 +118,20 @@ describe("cli entrypoint", () => {
     const dir = await mkdtemp(path.join(tmpdir(), "distill-onboarding-"));
     const home = path.join(dir, "home");
     const configPath = path.join(dir, "config.json");
+    const oldBlock = [
+      "keep before",
+      "<!-- distill skill: begin -->",
+      "old distill instructions",
+      "<!-- distill skill: end -->",
+      "keep after"
+    ].join("\n");
 
     try {
+      await mkdir(path.join(home, ".codex"), { recursive: true });
+      await mkdir(path.join(home, ".claude"), { recursive: true });
+      await writeFile(path.join(home, ".codex", "AGENTS.md"), oldBlock);
+      await writeFile(path.join(home, ".claude", "CLAUDE.md"), oldBlock);
+
       const result = spawnSync("bun", ["run", cli], {
         cwd: root,
         encoding: "utf8",
@@ -159,12 +171,40 @@ describe("cli entrypoint", () => {
           "utf8"
         )
       ).toContain("name: distill");
-      expect(await readFile(path.join(home, ".codex", "AGENTS.md"), "utf8")).toContain(
-        "Use `/distill` whenever"
+      const codexInstructions = await readFile(
+        path.join(home, ".codex", "AGENTS.md"),
+        "utf8"
       );
-      expect(await readFile(path.join(home, ".claude", "CLAUDE.md"), "utf8")).toContain(
-        "Use `/distill` whenever"
+      const claudeInstructions = await readFile(
+        path.join(home, ".claude", "CLAUDE.md"),
+        "utf8"
       );
+
+      for (const instructions of [codexInstructions, claudeInstructions]) {
+        expect(instructions).toContain("keep before");
+        expect(instructions).toContain("keep after");
+        expect(instructions).not.toContain("old distill instructions");
+        expect(
+          instructions.match(/<!-- distill skill: begin -->/g) ?? []
+        ).toHaveLength(1);
+        expect(instructions).toContain("Always communicate with the user in `/distill`");
+        expect(instructions).toContain(
+          "Do not return a rewritten/compressed copy of the user's prompt"
+        );
+        expect(instructions).toContain("Keep hidden chain-of-thought private");
+        expect(instructions).toContain(
+          "When running non-interactive shell commands, pipe output through `distill`"
+        );
+        expect(instructions).toContain(
+          'bun test 2>&1 | distill "Did tests pass? Return PASS or FAIL'
+        );
+        expect(instructions).toContain(
+          'git diff | distill "What changed? Return only files changed'
+        );
+        expect(instructions).toContain(
+          'terraform plan 2>&1 | distill "Is this safe? Return SAFE, REVIEW, or UNSAFE'
+        );
+      }
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- changes the /distill skill into a persistent conversation mode instead of returning rewritten prompts
- updates onboarding agent instructions to replace existing distill blocks with the latest version
- updates README copy and onboarding tests for the new behavior

## Tests
- bun test
- npm run verify
- npm pack --dry-run ./packages/cli