### PR TITLE
Add thread-end DSL learning

### DIFF
--- a/.claude/skills/distill/SKILL.md
+++ b/.claude/skills/distill/SKILL.md
@@ -139,7 +139,12 @@ Risk: not committed.
 
 ## Glossary And Memory
 
-Keep an internal alias dict per conversation. Do not create files.
+Use two memory layers:
+
+- thread dict: internal aliases for the current conversation
+- persisted dict: entries saved by `distill dsl learn`, `distill dsl learn-thread --stdin`, or explicit user action
+
+Do not manually create memory files. Let the `distill` CLI own JSON memory writes.
 
 Use aliases only when they stay obvious:
 
@@ -178,7 +183,15 @@ Dict: B=backend F=frontend 1=failing-test-first
 Dict+: A1=authentication bug fix
 ```
 
-Expire learned terms mentally if they stop appearing. A term should not become part of thread DSL unless it appears at least twice in a short window or the user explicitly approves it.
+Persisted learned terms start as candidates and promote only through lifecycle rules. A term should not become part of active DSL unless it appears at least twice in a short window or the user explicitly approves it.
+
+At thread end, when transcript export is available, run:
+
+```bash
+distill dsl learn-thread --stdin < transcript.txt
+```
+
+This analyzes repeated usage, rejects sensitive/noisy terms, asks the configured reviewer model for strict JSON, and persists only compact candidates.
 
 ## Tool Calls
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Manage DSL memory:
 distill dsl show
 distill dsl show --candidates
 distill dsl learn --dry-run "Dict+: A1=authentication fix"
+distill dsl learn-thread --stdin --dry-run < transcript.txt
 distill dsl promote --dry-run
 distill dsl add alias A1 "authentication bug fix" --scope project
 distill dsl add macro 1 "add failing regression test first" --scope global
@@ -47,6 +48,8 @@ distill dsl prune --dry-run
 ```
 
 Normal `distill` runs load only compact active DSL memory into the prompt. If the model emits reusable `Dict+` entries, `distill` learns them as project candidates using the shortest available key, promotes them after repeated use, and keeps stack/global promotion gated by `distill dsl promote`.
+
+At thread end, export or pipe the transcript through `distill dsl learn-thread --stdin`. It extracts repeated workflow language, asks the configured reviewer model for strict JSON, rejects sensitive/noisy terms, and saves approved entries as candidates.
 
 You can also pipe command output into `distill`:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,12 +20,15 @@ After onboarding, use `/distill` in Claude/Codex to make the agent keep talking 
 distill dsl show
 distill dsl show --candidates
 distill dsl learn --dry-run "Dict+: A1=authentication fix"
+distill dsl learn-thread --stdin --dry-run < transcript.txt
 distill dsl promote --dry-run
 distill dsl add alias A1 "authentication bug fix" --scope project
 distill dsl prune --dry-run
 ```
 
 Normal runs load compact active DSL memory into the prompt. Reusable `Dict+` entries from `/distill` output are learned as project candidates using the shortest available key and can later be promoted with `distill dsl promote`.
+
+At thread end, pipe a transcript into `distill dsl learn-thread --stdin`. It learns repeated workflow language as candidates after reviewer approval and sensitive-term filtering.
 
 You can also pipe command output into `distill`:
 

--- a/skills/distill/SKILL.md
+++ b/skills/distill/SKILL.md
@@ -139,7 +139,12 @@ Risk: not committed.
 
 ## Glossary And Memory
 
-Keep an internal alias dict per conversation. Do not create files.
+Use two memory layers:
+
+- thread dict: internal aliases for the current conversation
+- persisted dict: entries saved by `distill dsl learn`, `distill dsl learn-thread --stdin`, or explicit user action
+
+Do not manually create memory files. Let the `distill` CLI own JSON memory writes.
 
 Use aliases only when they stay obvious:
 
@@ -178,7 +183,15 @@ Dict: B=backend F=frontend 1=failing-test-first
 Dict+: A1=authentication bug fix
 ```
 
-Expire learned terms mentally if they stop appearing. A term should not become part of thread DSL unless it appears at least twice in a short window or the user explicitly approves it.
+Persisted learned terms start as candidates and promote only through lifecycle rules. A term should not become part of active DSL unless it appears at least twice in a short window or the user explicitly approves it.
+
+At thread end, when transcript export is available, run:
+
+```bash
+distill dsl learn-thread --stdin < transcript.txt
+```
+
+This analyzes repeated usage, rejects sensitive/noisy terms, asks the configured reviewer model for strict JSON, and persists only compact candidates.
 
 ## Tool Calls
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,11 +10,13 @@ import {
   learnFromDistillOutput,
   readMergedDslMemory,
   runDslCommand,
-  type DslPromotionReview
+  type DslPromotionReview,
+  type DslThreadLearnReview
 } from "./dsl-memory";
 import {
   summarizeBatch,
   summarizeDslPromotion,
+  summarizeThreadLearn,
   summarizeTranslate,
   summarizeWatch
 } from "./llm";
@@ -27,6 +29,25 @@ import {
   resolveConfigPath,
   setPersistedConfigValue
 } from "./user-config";
+
+async function readAllStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    throw new UsageError("stdin is required.");
+  }
+
+  const chunks: Buffer[] = [];
+
+  await new Promise<void>((resolve, reject) => {
+    process.stdin.on("data", (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    process.stdin.on("end", resolve);
+    process.stdin.on("error", reject);
+    process.stdin.resume();
+  });
+
+  return Buffer.concat(chunks).toString("utf8");
+}
 
 async function run(): Promise<number> {
   const persisted = await readPersistedConfig(process.env);
@@ -49,26 +70,28 @@ async function run(): Promise<number> {
 
   if (command.kind === "dsl") {
     const defaults = resolveRuntimeDefaults(process.env, persisted);
+    const runtimeConfig = {
+      question: "Review DSL memory.",
+      model: defaults.model,
+      host: defaults.host,
+      apiKey: defaults.apiKey,
+      timeoutMs: defaults.timeoutMs,
+      datasetEnabled: defaults.datasetEnabled,
+      datasetPath: defaults.datasetPath,
+      autoLearn: defaults.autoLearn,
+      autoLearnScope: defaults.autoLearnScope,
+      autoLearnSource: defaults.autoLearnSource,
+      autoPromoteScopes: defaults.autoPromoteScopes,
+      maxPromptDslEntries: defaults.maxPromptDslEntries
+    };
     process.stdout.write(
       await runDslCommand(command.args, {
         env: process.env,
         cwd: process.cwd(),
+        readStdin: readAllStdin,
         promotionReviewer: async (entries) => {
           const response = await summarizeDslPromotion(
-            {
-              question: "Review DSL promotion candidates.",
-              model: defaults.model,
-              host: defaults.host,
-              apiKey: defaults.apiKey,
-              timeoutMs: defaults.timeoutMs,
-              datasetEnabled: defaults.datasetEnabled,
-              datasetPath: defaults.datasetPath,
-              autoLearn: defaults.autoLearn,
-              autoLearnScope: defaults.autoLearnScope,
-              autoLearnSource: defaults.autoLearnSource,
-              autoPromoteScopes: defaults.autoPromoteScopes,
-              maxPromptDslEntries: defaults.maxPromptDslEntries
-            },
+            { ...runtimeConfig, question: "Review DSL promotion candidates." },
             entries
               .map(
                 (entry) =>
@@ -78,6 +101,20 @@ async function run(): Promise<number> {
           );
 
           return JSON.parse(response) as DslPromotionReview[];
+        },
+        threadLearnReviewer: async (request) => {
+          const dslMemory = formatPromptDslMemory(
+            request.dslMemory,
+            defaults.maxPromptDslEntries ?? 40
+          );
+          const response = await summarizeThreadLearn(
+            { ...runtimeConfig, question: "Review thread DSL candidates." },
+            request.transcript,
+            request.candidates,
+            dslMemory
+          );
+
+          return JSON.parse(response) as DslThreadLearnReview[];
         }
       })
     );

--- a/src/dsl-memory.ts
+++ b/src/dsl-memory.ts
@@ -41,6 +41,8 @@ interface DslCommandContext {
   cwd: string;
   now?: Date;
   promotionReviewer?: (entries: DslEntry[]) => Promise<DslPromotionReview[]>;
+  threadLearnReviewer?: (request: DslThreadLearnReviewRequest) => Promise<DslThreadLearnReview[]>;
+  readStdin?: () => Promise<string>;
 }
 
 export interface DslPromotionReview {
@@ -48,6 +50,32 @@ export interface DslPromotionReview {
   decision: "promote" | "keep" | "reject";
   targetScope: DslScope;
   reason: string;
+}
+
+export interface DslThreadLearnCandidate {
+  key: string;
+  meaning: string;
+  kind: DslKind;
+  scope: DslScope;
+  occurrenceCount: number;
+  source: "dict" | "phrase" | "command";
+}
+
+export interface DslThreadLearnReview {
+  key: string;
+  meaning: string;
+  kind: DslKind;
+  scope: DslScope;
+  reason: string;
+  confidence: number;
+}
+
+export interface DslThreadLearnReviewRequest {
+  transcript: string;
+  candidates: DslThreadLearnCandidate[];
+  dslMemory: DslEntry[];
+  scope: DslScope;
+  stack?: string;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -204,6 +232,7 @@ function parseFlags(args: string[]): {
   stale: boolean;
   candidates: boolean;
   dryRun: boolean;
+  stdin: boolean;
 } {
   const positional: string[] = [];
   let scope: DslScope = "project";
@@ -212,6 +241,7 @@ function parseFlags(args: string[]): {
   let stale = false;
   let candidates = false;
   let dryRun = false;
+  let stdin = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -247,6 +277,11 @@ function parseFlags(args: string[]): {
       continue;
     }
 
+    if (arg === "--stdin") {
+      stdin = true;
+      continue;
+    }
+
     if (arg.startsWith("-")) {
       throw new UsageError(`Unknown DSL flag: ${arg}`);
     }
@@ -254,7 +289,7 @@ function parseFlags(args: string[]): {
     positional.push(arg);
   }
 
-  return { positional, scope, scopeProvided, stack, stale, candidates, dryRun };
+  return { positional, scope, scopeProvided, stack, stale, candidates, dryRun, stdin };
 }
 
 function gcMemory(memory: DslMemoryFile, now: Date): { memory: DslMemoryFile; changed: boolean } {
@@ -591,6 +626,273 @@ function compactLearnedEntries(
   return compacted;
 }
 
+const THREAD_STOP_WORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "that",
+  "this",
+  "from",
+  "into",
+  "will",
+  "must",
+  "should",
+  "when",
+  "then",
+  "than",
+  "only",
+  "using",
+  "return",
+  "output",
+  "user",
+  "thread",
+  "please",
+  "implement",
+  "plan"
+]);
+
+function normalizeMeaning(input: string): string {
+  return input
+    .trim()
+    .replace(/[`"'*_>#()[\]{}]/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/[.,;:!?]+$/g, "")
+    .toLowerCase();
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function countMeaningOccurrences(transcript: string, meaning: string): number {
+  const normalizedTranscript = normalizeMeaning(transcript);
+  const normalizedMeaning = normalizeMeaning(meaning);
+
+  if (!normalizedMeaning) {
+    return 0;
+  }
+
+  return normalizedTranscript.match(new RegExp(`\\b${escapeRegExp(normalizedMeaning)}\\b`, "g"))?.length ?? 0;
+}
+
+function looksPrivateOrNoisy(input: string): boolean {
+  return (
+    containsSensitiveValue(input) ||
+    /[/\\]/.test(input) ||
+    /@\w/.test(input) ||
+    /\b[a-f0-9]{12,}\b/i.test(input) ||
+    /\b\d{4,}\b/.test(input) ||
+    /\b(samuel|samuelfaj|fajreldines)\b/i.test(input) ||
+    /\b[A-Z][a-z]+ [A-Z][a-z]+\b/.test(input)
+  );
+}
+
+function isReusableThreadMeaning(meaning: string, occurrenceCount: number): boolean {
+  const normalized = normalizeMeaning(meaning);
+
+  if (occurrenceCount < 2 || normalized.length < 3 || normalized.length > 120) {
+    return false;
+  }
+
+  if (looksPrivateOrNoisy(meaning)) {
+    return false;
+  }
+
+  const words = normalized.split(/\s+/).filter(Boolean);
+
+  if (words.length === 1 && words[0].length < 4) {
+    return false;
+  }
+
+  if (words.every((word) => THREAD_STOP_WORDS.has(word))) {
+    return false;
+  }
+
+  return true;
+}
+
+function candidateKeyFromMeaning(meaning: string): string {
+  const normalized = normalizeMeaning(meaning);
+  const important = normalized
+    .split(/\s+/)
+    .filter((word) => word && !THREAD_STOP_WORDS.has(word));
+
+  return (important[0] ?? normalized)[0]?.toUpperCase() ?? "Z";
+}
+
+function addThreadCandidate(
+  byMeaning: Map<string, DslThreadLearnCandidate>,
+  scope: DslScope,
+  kind: DslKind,
+  meaning: string,
+  occurrenceCount: number,
+  source: DslThreadLearnCandidate["source"],
+  rawKey?: string
+): void {
+  const normalized = normalizeMeaning(meaning);
+
+  if (!isReusableThreadMeaning(normalized, occurrenceCount)) {
+    return;
+  }
+
+  const existing = byMeaning.get(normalized);
+
+  if (existing && existing.occurrenceCount >= occurrenceCount) {
+    return;
+  }
+
+  byMeaning.set(normalized, {
+    key: rawKey ? normalizeKey(rawKey) : candidateKeyFromMeaning(normalized),
+    meaning: normalized,
+    kind,
+    scope,
+    occurrenceCount,
+    source
+  });
+}
+
+function extractRepeatedLineCommands(transcript: string): Array<{ meaning: string; count: number }> {
+  const counts = new Map<string, number>();
+
+  for (const rawLine of transcript.split(/\r?\n/)) {
+    const line = rawLine
+      .trim()
+      .replace(/^\$+\s*/, "")
+      .replace(/^>\s*/, "");
+
+    if (!line || line.length > 120) {
+      continue;
+    }
+
+    if (!/\b(bun|npm|pnpm|yarn|git|gh|glab|terraform|distill|pytest|cargo|go|swift|xcodebuild)\b/.test(line)) {
+      continue;
+    }
+
+    if (looksPrivateOrNoisy(line)) {
+      continue;
+    }
+
+    const normalized = normalizeMeaning(line);
+    counts.set(normalized, (counts.get(normalized) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .filter(([, count]) => count >= 2)
+    .map(([meaning, count]) => ({ meaning, count }));
+}
+
+function extractRepeatedPhrases(transcript: string): Array<{ meaning: string; count: number }> {
+  const normalized = normalizeMeaning(transcript);
+  const words = normalized.split(/\s+/).filter((word) => /^[a-z][a-z0-9-]{2,}$/.test(word));
+  const counts = new Map<string, number>();
+
+  for (let size = 2; size <= 4; size += 1) {
+    for (let index = 0; index <= words.length - size; index += 1) {
+      const phraseWords = words.slice(index, index + size);
+
+      if (phraseWords.every((word) => THREAD_STOP_WORDS.has(word))) {
+        continue;
+      }
+
+      if (phraseWords.some((word) => word.length > 40)) {
+        continue;
+      }
+
+      const phrase = phraseWords.join(" ");
+      counts.set(phrase, (counts.get(phrase) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .filter(([meaning, count]) => isReusableThreadMeaning(meaning, count))
+    .sort((a, b) => b[1] - a[1] || a[0].length - b[0].length)
+    .slice(0, 40)
+    .map(([meaning, count]) => ({ meaning, count }));
+}
+
+export function extractThreadLearnCandidates(
+  transcript: string,
+  scope: DslScope
+): DslThreadLearnCandidate[] {
+  const byMeaning = new Map<string, DslThreadLearnCandidate>();
+
+  for (const entry of parseDictEntries(transcript)) {
+    const count = Math.max(
+      countMeaningOccurrences(transcript, entry.meaning),
+      countMeaningOccurrences(transcript, entry.key)
+    );
+    addThreadCandidate(byMeaning, scope, entry.kind, entry.meaning, count, "dict", entry.key);
+  }
+
+  for (const command of extractRepeatedLineCommands(transcript)) {
+    addThreadCandidate(byMeaning, scope, "macro", command.meaning, command.count, "command");
+  }
+
+  for (const phrase of extractRepeatedPhrases(transcript)) {
+    addThreadCandidate(
+      byMeaning,
+      scope,
+      inferKind(candidateKeyFromMeaning(phrase.meaning), phrase.meaning),
+      phrase.meaning,
+      phrase.count,
+      "phrase"
+    );
+  }
+
+  return [...byMeaning.values()]
+    .sort((a, b) => b.occurrenceCount - a.occurrenceCount || a.meaning.length - b.meaning.length)
+    .slice(0, 30);
+}
+
+function deterministicThreadReviews(
+  candidates: DslThreadLearnCandidate[]
+): DslThreadLearnReview[] {
+  return candidates.map((candidate) => ({
+    key: candidate.key,
+    meaning: candidate.meaning,
+    kind: candidate.kind,
+    scope: candidate.scope,
+    reason: `${candidate.source} repeated ${candidate.occurrenceCount} times`,
+    confidence: 0.7
+  }));
+}
+
+function validThreadReview(
+  review: DslThreadLearnReview,
+  targetScope: DslScope
+): DslThreadLearnReview | undefined {
+  if (!["alias", "macro", "default"].includes(review.kind)) {
+    return undefined;
+  }
+
+  if (!["project", "stack", "global"].includes(review.scope) || review.scope !== targetScope) {
+    return undefined;
+  }
+
+  const confidence = Number(review.confidence);
+
+  if (!Number.isFinite(confidence) || confidence < 0.65) {
+    return undefined;
+  }
+
+  const key = normalizeKey(review.key);
+  const meaning = normalizeMeaning(review.meaning);
+
+  if (!isReusableThreadMeaning(meaning, 2)) {
+    return undefined;
+  }
+
+  return {
+    key,
+    meaning,
+    kind: review.kind,
+    scope: review.scope,
+    reason: String(review.reason ?? "").slice(0, 160),
+    confidence
+  };
+}
+
 export async function seedGlobalDslMemory(
   env: NodeJS.ProcessEnv,
   now: Date = new Date()
@@ -713,6 +1015,137 @@ export async function learnFromDistillOutput(
           env,
           cwd,
           "project",
+          options.stack,
+          entry.kind,
+          entry.key,
+          entry.meaning,
+          now
+        )
+      ).trim()
+    );
+  }
+
+  return `${results.join("\n")}\n`;
+}
+
+export async function learnFromThreadTranscript(
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+  transcript: string,
+  options: {
+    scope?: DslScope;
+    dryRun?: boolean;
+    stack?: string;
+    now?: Date;
+    reviewer?: (request: DslThreadLearnReviewRequest) => Promise<DslThreadLearnReview[]>;
+  } = {}
+): Promise<string> {
+  const now = options.now ?? new Date();
+  const scope = options.scope ?? "project";
+
+  if (!transcript.trim()) {
+    throw new UsageError("DSL learn-thread requires non-empty stdin.");
+  }
+
+  const extracted = extractThreadLearnCandidates(transcript, scope);
+  const mergedMemory = await readMergedDslMemory(env, cwd, options.stack, now);
+  const { memory: targetMemory } = await readScopedMemory(
+    env,
+    scope,
+    cwd,
+    options.stack,
+    now
+  );
+  const allExisting = [...mergedMemory, ...targetMemory.entries];
+  const compacted = compactLearnedEntries(extracted, allExisting).map((entry) => {
+    const source = extracted.find((candidate) => candidate.meaning === entry.meaning);
+    return {
+      ...entry,
+      scope,
+      occurrenceCount: source?.occurrenceCount ?? 2,
+      source: source?.source ?? "phrase"
+    } satisfies DslThreadLearnCandidate;
+  });
+
+  if (compacted.length === 0) {
+    return `${options.dryRun ? "would learn-thread" : "learn-thread"} 0 entries\n`;
+  }
+
+  let reviewed = deterministicThreadReviews(compacted);
+
+  if (options.reviewer) {
+    try {
+      reviewed = await options.reviewer({
+        transcript,
+        candidates: compacted,
+        dslMemory: mergedMemory,
+        scope,
+        stack: options.stack
+      });
+    } catch {
+      reviewed = deterministicThreadReviews(compacted);
+    }
+  }
+
+  const pinnedKeys = new Set(
+    allExisting
+      .filter((entry) => entry.status === "pinned" || entry.builtin)
+      .map((entry) => entry.key)
+  );
+  const approvedByMeaning = new Map<string, DslThreadLearnReview>();
+
+  for (const review of reviewed) {
+    const valid = validThreadReview(review, scope);
+
+    if (!valid || pinnedKeys.has(valid.key)) {
+      continue;
+    }
+
+    if (!extracted.some((candidate) => candidate.meaning === valid.meaning)) {
+      continue;
+    }
+
+    approvedByMeaning.set(valid.meaning, valid);
+  }
+
+  const approved = compactLearnedEntries(
+    [...approvedByMeaning.values()].map((entry) => ({
+      key: entry.key,
+      meaning: entry.meaning,
+      kind: entry.kind
+    })),
+    allExisting
+  )
+    .filter((entry) => !pinnedKeys.has(entry.key))
+    .map((entry) => ({
+      ...entry,
+      scope,
+      reason: approvedByMeaning.get(entry.meaning)?.reason ?? "accepted",
+      confidence: approvedByMeaning.get(entry.meaning)?.confidence ?? 0.7
+    }));
+
+  if (approved.length === 0) {
+    return `${options.dryRun ? "would learn-thread" : "learn-thread"} 0 entries\n`;
+  }
+
+  if (options.dryRun) {
+    return `would learn-thread ${approved.length} entries in ${scope}\n${approved
+      .map(
+        (entry) =>
+          `${entry.key}\t${entry.kind}\t${entry.scope}\t${entry.confidence.toFixed(2)}\t${entry.meaning}\t${entry.reason}`
+      )
+      .join("\n")}\n`;
+  }
+
+  const results: string[] = [];
+
+  for (const entry of approved) {
+    results.push(
+      (
+        await addEntry(
+          env,
+          cwd,
+          scope,
           options.stack,
           entry.kind,
           entry.key,
@@ -1074,6 +1507,24 @@ export async function runDslCommand(
     });
   }
 
+  if (action === "learn-thread") {
+    if (!parsed.stdin) {
+      throw new UsageError("DSL learn-thread requires --stdin.");
+    }
+
+    if (!context.readStdin) {
+      throw new UsageError("DSL learn-thread cannot read stdin in this context.");
+    }
+
+    return learnFromThreadTranscript(context.env, context.cwd, await context.readStdin(), {
+      scope: parsed.scope,
+      dryRun: parsed.dryRun,
+      stack: parsed.stack,
+      now,
+      reviewer: context.threadLearnReviewer
+    });
+  }
+
   if (action === "promote") {
     return promoteMemory(context, parsed.stack, parsed.dryRun, now);
   }
@@ -1082,5 +1533,7 @@ export async function runDslCommand(
     return resetMemory(context.env, context.cwd, parsed.scope, parsed.stack);
   }
 
-  throw new UsageError("DSL command must be show, add, pin, learn, promote, prune, or reset.");
+  throw new UsageError(
+    "DSL command must be show, add, pin, learn, learn-thread, promote, prune, or reset."
+  );
 }

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -2,6 +2,7 @@ import type { RuntimeConfig } from "./config";
 import {
   buildBatchPrompt,
   buildDslPromotionPrompt,
+  buildThreadLearnPrompt,
   buildTranslatePrompt,
   buildWatchPrompt,
   type PromptMessages
@@ -169,4 +170,18 @@ export function summarizeDslPromotion(
   fetchImpl?: typeof fetch
 ): Promise<string> {
   return summarize(config, buildDslPromotionPrompt(entries), fetchImpl);
+}
+
+export function summarizeThreadLearn(
+  config: RuntimeConfig,
+  transcript: string,
+  candidates: Parameters<typeof buildThreadLearnPrompt>[1],
+  dslMemory: string,
+  fetchImpl?: typeof fetch
+): Promise<string> {
+  return summarize(
+    config,
+    buildThreadLearnPrompt(transcript, candidates, dslMemory),
+    fetchImpl
+  );
 }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -7,6 +7,15 @@ export interface BatchPromptOptions {
   dslMemory?: string;
 }
 
+export interface ThreadLearnPromptCandidate {
+  key: string;
+  meaning: string;
+  kind: "alias" | "macro" | "default";
+  scope: "global" | "stack" | "project";
+  occurrenceCount: number;
+  source: string;
+}
+
 const SAFETY_BIAS = [
   "SAFETY:",
   "When the question asks to classify risk, safety, or destructiveness",
@@ -217,6 +226,40 @@ export function buildDslPromotionPrompt(entries: string): PromptMessages {
   return {
     system,
     user: ["Entries:", fitInput(entries, 4000)].join("\n")
+  };
+}
+
+export function buildThreadLearnPrompt(
+  transcript: string,
+  candidates: ThreadLearnPromptCandidate[],
+  dslMemory: string
+): PromptMessages {
+  const system = [
+    "You review /distill DSL candidates learned from a whole agent thread.",
+    "Return valid JSON only.",
+    "Input candidates were extracted deterministically from repeated thread usage.",
+    "Keep only stable, reusable operational language that will reduce future repetition.",
+    "Reject secrets, tokens, emails, URLs, file paths, IDs, hashes, personal names,",
+    "package names, project-private names, one-off wording, and ambiguous meanings.",
+    "Prefer the shortest unambiguous key: one letter or one number first, then letter+number.",
+    "Do not duplicate existing DSL memory. Do not overwrite pinned meanings.",
+    "Use scope project unless the candidate is clearly generic for the requested scope.",
+    "Schema: [{\"key\":\"A\",\"meaning\":\"short meaning\",\"kind\":\"alias|macro|default\",\"scope\":\"project|stack|global\",\"reason\":\"short reason\",\"confidence\":0.0}]",
+    "Use confidence 0.65 or higher only when the candidate is safe to persist."
+  ].join(" ");
+
+  return {
+    system,
+    user: [
+      "Existing active DSL memory:",
+      dslMemory || "(empty)",
+      "",
+      "Deterministic candidates:",
+      JSON.stringify(candidates, null, 2),
+      "",
+      "Thread transcript:",
+      fitInput(transcript, 10000)
+    ].join("\n")
   };
 }
 

--- a/test/dsl-memory.test.ts
+++ b/test/dsl-memory.test.ts
@@ -6,11 +6,13 @@ import path from "node:path";
 import {
   formatPromptDslMemory,
   hashProjectPath,
+  learnFromThreadTranscript,
   learnFromDistillOutput,
   readMergedDslMemory,
   resolveDslScopePath,
   runDslCommand,
-  seedGlobalDslMemory
+  seedGlobalDslMemory,
+  type DslThreadLearnReview
 } from "../src/dsl-memory";
 
 function daysFromNow(days: number): Date {
@@ -372,6 +374,155 @@ describe("dsl memory", () => {
       expect(activeLearned).toHaveLength(20);
       expect(output).not.toContain("TERM0\talias\tactive");
       expect(output).not.toContain("TERM1\talias\tactive");
+    });
+  });
+
+  it("dry-runs thread learning with reviewed repeated candidates", async () => {
+    await withEnv(async (env, cwd) => {
+      const transcript = [
+        "Need run tests before commit.",
+        "Please run tests after patch.",
+        "Dict+: RF=release flow",
+        "release flow is repeated",
+        "release flow again"
+      ].join("\n");
+      const output = await learnFromThreadTranscript(env, cwd, transcript, {
+        dryRun: true,
+        now: daysFromNow(0),
+        reviewer: async (request): Promise<DslThreadLearnReview[]> => {
+          expect(request.candidates.some((entry) => entry.meaning === "release flow")).toBe(true);
+          return [
+            {
+              key: "R",
+              meaning: "release flow",
+              kind: "macro",
+              scope: "project",
+              reason: "stable repeated workflow",
+              confidence: 0.9
+            }
+          ];
+        }
+      });
+
+      expect(output).toContain("would learn-thread 1 entries in project");
+      expect(output).toContain("R\tmacro\tproject\t0.90\trelease flow");
+      expect(
+        await runDslCommand(["show", "--scope", "project"], {
+          env,
+          cwd,
+          now: daysFromNow(0)
+        })
+      ).toContain("(empty)");
+    });
+  });
+
+  it("writes thread-learned entries as candidates and promotes by lifecycle on repeat", async () => {
+    await withEnv(async (env, cwd) => {
+      const transcript = "review release flow\nrelease flow needs check\n";
+      const reviewer = async (): Promise<DslThreadLearnReview[]> => [
+        {
+          key: "R",
+          meaning: "release flow",
+          kind: "macro",
+          scope: "project",
+          reason: "repeated workflow",
+          confidence: 0.9
+        }
+      ];
+
+      const first = await learnFromThreadTranscript(env, cwd, transcript, {
+        now: daysFromNow(0),
+        reviewer
+      });
+      const second = await learnFromThreadTranscript(env, cwd, transcript, {
+        now: daysFromNow(1),
+        reviewer
+      });
+      const output = await runDslCommand(["show", "--scope", "project"], {
+        env,
+        cwd,
+        now: daysFromNow(1)
+      });
+
+      expect(first).toContain("candidate R added to project");
+      expect(second).toContain("active R updated in project");
+      expect(output).toContain("R\tmacro\tactive\trelease flow");
+    });
+  });
+
+  it("rejects sensitive thread candidates even when the reviewer approves them", async () => {
+    await withEnv(async (env, cwd) => {
+      const transcript = [
+        "token sk-1234567890abcdef repeated",
+        "token sk-1234567890abcdef repeated",
+        "https://example.com/path",
+        "https://example.com/path"
+      ].join("\n");
+      const output = await learnFromThreadTranscript(env, cwd, transcript, {
+        now: daysFromNow(0),
+        reviewer: async () => [
+          {
+            key: "S",
+            meaning: "secret token value",
+            kind: "alias",
+            scope: "project",
+            reason: "bad approval",
+            confidence: 0.99
+          }
+        ]
+      });
+
+      expect(output).toContain("learn-thread 0 entries");
+      expect(
+        await runDslCommand(["show", "--scope", "project"], {
+          env,
+          cwd,
+          now: daysFromNow(0)
+        })
+      ).toContain("(empty)");
+    });
+  });
+
+  it("does not overwrite pinned entries during thread learning", async () => {
+    await withEnv(async (env, cwd) => {
+      await runDslCommand(["add", "alias", "Z", "pinned meaning", "--scope", "project"], {
+        env,
+        cwd,
+        now: daysFromNow(0)
+      });
+      await runDslCommand(["pin", "Z", "--scope", "project"], {
+        env,
+        cwd,
+        now: daysFromNow(0)
+      });
+
+      const output = await learnFromThreadTranscript(
+        env,
+        cwd,
+        "release flow release flow release flow",
+        {
+          now: daysFromNow(1),
+          reviewer: async () => [
+            {
+              key: "Z",
+              meaning: "release flow",
+              kind: "macro",
+              scope: "project",
+              reason: "would overwrite pinned key",
+              confidence: 0.95
+            }
+          ]
+        }
+      );
+      const memory = await runDslCommand(["show", "--scope", "project"], {
+        env,
+        cwd,
+        now: daysFromNow(1)
+      });
+
+      expect(output).toContain("learn-thread 0 entries");
+      expect(memory).toContain("Z\talias\tpinned\tpinned meaning");
+      expect(memory).not.toContain("release flow");
     });
   });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -343,6 +343,74 @@ describe("distill end-to-end", () => {
     }
   });
 
+  it("learns DSL candidates from a thread transcript through the reviewer", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "distill-e2e-thread-dsl-"));
+    const env = {
+      DISTILL_CONFIG_PATH: path.join(dir, "config.json")
+    };
+    const fake = await createFakeChatProvider((body) => {
+      const prompt = JSON.stringify(body);
+
+      expect(prompt).toContain("Deterministic candidates");
+      expect(prompt).toContain("Thread transcript");
+      expect(prompt).toContain("release flow");
+
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify([
+                  {
+                    key: "R",
+                    meaning: "release flow",
+                    kind: "macro",
+                    scope: "project",
+                    reason: "repeated workflow",
+                    confidence: 0.9
+                  },
+                  {
+                    key: "S",
+                    meaning: "secret token value",
+                    kind: "alias",
+                    scope: "project",
+                    reason: "sensitive",
+                    confidence: 0.99
+                  }
+                ])
+              }
+            }
+          ]
+        }),
+        { status: 200 }
+      );
+    });
+
+    try {
+      const transcript = [
+        "release flow needs npm publish",
+        "release flow needs github release",
+        "secret token value secret token value"
+      ].join("\n");
+      const result = await runLauncher(["dsl", "learn-thread", "--stdin"], {
+        env: createProviderEnv(fake.host, env),
+        inputSteps: [{ data: transcript }]
+      });
+      const shown = await runLauncher(["dsl", "show", "--scope", "project"], {
+        env
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("candidate R added to project");
+      expect(shown.stdout).toContain("R\tmacro\tcandidate\trelease flow");
+      expect(shown.stdout).not.toContain("secret token value");
+      expect(fake.requests).toHaveLength(1);
+    } finally {
+      fake.stop();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("translates /distill output without requiring stdin", async () => {
     const fake = await createFakeChatProvider((_body, _index) =>
       new Response(


### PR DESCRIPTION
## Summary
- add `distill dsl learn-thread --stdin` for transcript-based DSL candidate learning
- add deterministic extraction, reviewer prompt, CLI wiring, and lifecycle-safe persistence
- update /distill skill docs and README usage for persisted thread learning

## Verification
- `bun test`
- `npm run build`
- `npm run verify`
- `npm pack --dry-run ./packages/cli`
- reinstalled Codex and Claude /distill skills via onboarding
- smoke-tested Codex and Claude CLI /distill activation
